### PR TITLE
Example finding feasible points with no loss / zero bandwidth

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -12,6 +12,7 @@ Here is a collection of notebooks demonstrating the capabilities of Dolphindes.
    GCD Method <examples/limits/LDOS_gcd>
    Planewave Absorption <examples/limits/planewave_absorption>
    Polar Coordinates <examples/limits/LDOS_polar>
+   Polar Coordinates with Lossless Materials <examples/limits/LDOS_polar_lossless>
 
 .. toctree::
    :maxdepth: 1

--- a/dolphindes/cvxopt/gcd.py
+++ b/dolphindes/cvxopt/gcd.py
@@ -53,7 +53,7 @@ class GCDHyperparameters:
     gcd_tol: float = 1e-2
 
 
-def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int = 2) -> None:
+def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int | float = 2) -> None:
     """
     Merge the first m shared projection constraints of QCQP into a single one.
 
@@ -63,8 +63,9 @@ def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int = 2) -> None:
     ----------
     QCQP : _SharedProjQCQP
         QCQP for which we merge the leading constraints.
-    merged_num : int (optional, default 2)
+    merged_num : int | float (optional, default 2)
         Number of leading constraints that we are merging together; must be at least 2.
+        If infinity, we merge all existing constraints together.
 
     Raises
     ------
@@ -74,11 +75,13 @@ def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int = 2) -> None:
     proj_cstrt_num = len(QCQP.Proj)
     if merged_num < 2:
         raise ValueError("Need at least 2 constraints for merging.")
-    if proj_cstrt_num < merged_num:
-        raise ValueError("Number of constraints insufficient for size of merge.")
-
     if QCQP.current_lags is None:
         raise ValueError("Cannot merge constraints: QCQP.current_lags is None.")
+
+    if np.isinf(merged_num):
+        merged_num = proj_cstrt_num
+    elif proj_cstrt_num < merged_num:
+        raise ValueError("Number of constraints insufficient for size of merge.")
 
     new_P = QCQP.Proj.Pstruct.astype(complex, copy=True)
     new_P.data[:] = 0.0

--- a/dolphindes/cvxopt/gcd.py
+++ b/dolphindes/cvxopt/gcd.py
@@ -83,6 +83,7 @@ def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int | float = 2) -
     elif proj_cstrt_num < merged_num:
         raise ValueError("Number of constraints insufficient for size of merge.")
 
+    assert isinstance(merged_num, int)
     new_P = QCQP.Proj.Pstruct.astype(complex, copy=True)
     new_P.data[:] = 0.0
     for i in range(merged_num):

--- a/dolphindes/photonics/_base_photonics.py
+++ b/dolphindes/photonics/_base_photonics.py
@@ -244,6 +244,35 @@ class Photonics_FDFD(ABC):
         if c0 is not None:
             self.c0 = c0
 
+    def _build_projector_list(
+        self, n_des: int, Pdiags: str, phase: float | None = None
+    ) -> list[sp.csc_array]:
+        """Build the projector list for the requested shared-constraint basis."""
+        Id = sp.eye_array(n_des, dtype=complex, format="csc")
+
+        if Pdiags == "global":
+            return [Id, (-1j) * Id]
+
+        if Pdiags == "local":
+            local_one_hot_projectors = [
+                sp.csc_array(
+                    ([1.0], ([idx], [idx])),
+                    shape=(n_des, n_des),
+                    dtype=complex,
+                )
+                for idx in range(n_des)
+            ]
+            return local_one_hot_projectors + [
+                (-1j) * projector for projector in local_one_hot_projectors
+            ]
+
+        if Pdiags == "phase":
+            if phase is None:
+                raise ValueError("phase argument must be specified for Pdiags='phase'")
+            return [np.exp(1j * phase) * Id]
+
+        raise ValueError("Not a valid Pdiags specification / needs implementation")
+
     def setup_QCQP(
         self, Pdiags: str = "global", verbose: float = 0, phase: float | None = None
     ) -> None:
@@ -253,8 +282,9 @@ class Photonics_FDFD(ABC):
         Parameters
         ----------
         Pdiags : str or ndarray, optional
-            Specification for projection matrix diagonals. If "global", creates
-            global projectors with ones and -1j entries. Default: "global"
+            Specification for projection matrix diagonals. "global" creates
+            [I, -1j I], "local" creates [E_i, -1j E_i] one-hot projectors,
+            and "phase" creates [exp(1j * phase) I]. Default: "global"
         verbose : float, optional
             Verbosity level for debugging output. Default: 0
 
@@ -288,16 +318,7 @@ class Photonics_FDFD(ABC):
 
         self.get_ei(self.ji, update=True)
 
-        if Pdiags == "global":
-            Id = sp.eye_array(self.Ndes, dtype=complex, format="csc")
-            self.Plist = [Id, (-1j) * Id]
-        elif Pdiags == "phase":
-            if phase is None:
-                raise ValueError("phase argument must be specified for Pdiags='phase'")
-            Id = sp.eye_array(self.Ndes, dtype=complex, format="csc")
-            self.Plist = [np.exp(1j * phase) * Id]
-        else:
-            raise ValueError("Not a valid Pdiags specification / needs implementation")
+        self.Plist = self._build_projector_list(self.Ndes, Pdiags, phase)
 
         assert self.chi is not None
         assert self.ei is not None

--- a/examples/limits/LDOS_polar_lossless.ipynb
+++ b/examples/limits/LDOS_polar_lossless.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Cavity LDOS Bounds for Lossless Systems\n",
+    "Lossless, zero-bandwidth systems require special care for finding an initial point for the dual optimization. Eventually, this will be supported natively in Dolphindes. For now, this is an experimental notebook that shows how to do this for LDOS enhancement using a MOSEK feasibility problem. The theory remains unpublished, but will be updated here when it is.\n",
+    "\n",
+    "Note 1: cvxpy + MOSEK are not required to intsall Dolphindes to keep it lightweight. If you'd like to run this notebook, you will need to install these into your environment.\n",
+    "Note 2: This does not currently support quadratic objectives or general constraints.\n",
+    "\n",
+    "This notebook is a work in progress and is experimental."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "import numpy as np\n",
+    "import scipy.sparse as sp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from dolphindes import geometry, photonics\n",
+    "from dolphindes.cvxopt import gcd, OptimizationHyperparameters\n",
+    "from dolphindes.maxwell import plot_real_polar_field, plot_cplx_polar_field, expand_symmetric_field, TM_Polar_FDFD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Problem Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chi = 5\n",
+    "wvlgth = 1.0\n",
+    "Qabs = np.inf\n",
+    "omega = 2*np.pi / wvlgth * (1 + 1j/2/Qabs)\n",
+    "\n",
+    "R_nonpml = 3.5 # Total R\n",
+    "w_pml = 0.5 # surrounding pml thickness\n",
+    "R_tot = R_nonpml + w_pml # total computational domain radius\n",
+    "R_i = 0.02 # inner radius of the cavity\n",
+    "R_o = 1.0 # outer radius of the cavity\n",
+    "assert R_o < R_nonpml, \"Outer radius must be within non-PML region\"\n",
+    "\n",
+    "gpr = 30\n",
+    "dr = 1.0/gpr\n",
+    "Nr = int(np.round(R_tot / dr))\n",
+    "Npml = int(np.round(w_pml / dr))\n",
+    "Nr_i = int(np.round(R_i / dr))\n",
+    "Nr_o = int(np.round(R_o / dr))\n",
+    "Nphi = 108  # if Nphi = n_sectors = 1, we enforce cylindrical symmetry\n",
+    "n_sectors = 6\n",
+    "Nphi_sector = int(Nphi/n_sectors)\n",
+    "\n",
+    "assert Nphi % n_sectors == 0, \"Nphi must be divisible by n_sectors\"\n",
+    "\n",
+    "# If the problem is small enough, we can solve the full local problem.\n",
+    "# Otherwise we will run GCD.\n",
+    "SOLVE_LOCAL = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "condition number of U_sym: 533.4755502545198\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Normalize source so integrated current in the central pixel = 1\n",
+    "J_r = np.zeros(Nr)\n",
+    "J_r[0] = 1.0 / (np.pi * dr**2)  # central pixel current density = 1/area\n",
+    "J = np.kron(np.ones(Nphi_sector), J_r) \n",
+    "phi_grid = np.linspace(0, 2*np.pi, Nphi, endpoint=False)\n",
+    "r_grid = (np.arange(Nr) + 0.5) * dr\n",
+    "\n",
+    "des_mask_polar_sector = np.zeros((Nr, Nphi_sector), dtype=bool)\n",
+    "for i, r in enumerate(r_grid):\n",
+    "    if R_i <= r <= R_o:\n",
+    "        des_mask_polar_sector[i, :] = True\n",
+    "ndof = np.sum(des_mask_polar_sector)\n",
+    "\n",
+    "# 2. Instantiate the geometry using Nphi_sector\n",
+    "geo_polar = geometry.PolarFDFDGeometry(Nphi_sector, Nr, Npml, dr, n_sectors=n_sectors)\n",
+    "solver = TM_Polar_FDFD(omega, geo_polar)\n",
+    "Ei_sector = solver.get_TM_field(J)\n",
+    "G0 = solver.get_TM_Gba(des_mask_polar_sector, des_mask_polar_sector)\n",
+    "U = np.eye(ndof) * chi**(-1) - G0\n",
+    "\n",
+    "mask_1d = des_mask_polar_sector.flatten(order=\"F\")\n",
+    "A_full_sector = geo_polar.get_pixel_areas()\n",
+    "A_des = A_full_sector[mask_1d]\n",
+    "\n",
+    "W_diag = np.sqrt(A_des)\n",
+    "Winv_diag = 1.0 / W_diag\n",
+    "\n",
+    "# 3. Symmetrize the Green's function and U matrix\n",
+    "# The photonics class does this by default but here we are explicitly building these matrices in a lightweight manner\n",
+    "# <P|W @ G0 @ W_inv|P> gives <P|G0_{analytical} A|P>, which is what we want, but symmetrized.\n",
+    "# The chi term does not need this since it cancels out.\n",
+    "# We do not need to scale the incident field since we will be doing it when we build the photonics problem later.\n",
+    "G0_sym = G0 * W_diag[:, None] * Winv_diag[None, :]\n",
+    "U_sym = np.eye(ndof) * chi**(-1) - G0_sym\n",
+    "assert np.allclose(U_sym, U_sym.T, atol=1e-10), \"U_sym is not strictly symmetric.\"\n",
+    "print(\"condition number of U_sym:\", np.linalg.cond(U_sym))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ndof: 522\n",
+      "Vacuum LDOS (total): 0.7893\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"ndof: {ndof}\")\n",
+    "LDOS_vac = -0.5 * np.real(n_sectors * np.sum(np.conj(J) * Ei_sector * geo_polar.get_pixel_areas()))\n",
+    "print(f\"Vacuum LDOS (total): {LDOS_vac:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(CVXPY) May 25 03:45:09 PM: Your problem has 522 variables, 272484 constraints, and 0 parameters.\n",
+      "(CVXPY) May 25 03:45:09 PM: It is compliant with the following grammars: DCP, DQCP\n",
+      "(CVXPY) May 25 03:45:09 PM: (If you need to solve this problem multiple times, but with different data, consider using parameters.)\n",
+      "(CVXPY) May 25 03:45:09 PM: CVXPY will first compile your problem; then, it will invoke a numerical solver to obtain a solution.\n",
+      "(CVXPY) May 25 03:45:09 PM: Your problem is compiled with the CPP canonicalization backend.\n",
+      "(CVXPY) May 25 03:45:09 PM: Compiling problem (target solver=MOSEK).\n",
+      "(CVXPY) May 25 03:45:09 PM: Reduction chain: Complex2Real -> Dcp2Cone -> CvxAttr2Constr -> ConeMatrixStuffing -> MOSEK\n",
+      "(CVXPY) May 25 03:45:09 PM: Applying reduction Complex2Real\n",
+      "(CVXPY) May 25 03:45:09 PM: Applying reduction Dcp2Cone\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(CVXPY) May 25 03:45:09 PM: Applying reduction CvxAttr2Constr\n",
+      "(CVXPY) May 25 03:45:09 PM: Applying reduction ConeMatrixStuffing\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===============================================================================\n",
+      "                                     CVXPY                                     \n",
+      "                                     v1.7.5                                    \n",
+      "===============================================================================\n",
+      "-------------------------------------------------------------------------------\n",
+      "                                  Compilation                                  \n",
+      "-------------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(CVXPY) May 25 03:45:12 PM: Applying reduction MOSEK\n",
+      "(CVXPY) May 25 03:45:15 PM: Finished problem compilation (took 5.720e+00 seconds).\n",
+      "(CVXPY) May 25 03:45:15 PM: Invoking solver MOSEK  to obtain a solution.\n",
+      "(CVXPY) May 25 03:45:15 PM: Problem\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------\n",
+      "                                Numerical solver                               \n",
+      "-------------------------------------------------------------------------------\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(CVXPY) May 25 03:45:15 PM:   Name                   :                 \n",
+      "(CVXPY) May 25 03:45:15 PM:   Objective sense        : maximize        \n",
+      "(CVXPY) May 25 03:45:15 PM:   Type                   : CONIC (conic optimization problem)\n",
+      "(CVXPY) May 25 03:45:15 PM:   Constraints            : 1044            \n",
+      "(CVXPY) May 25 03:45:15 PM:   Affine conic cons.     : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM:   Disjunctive cons.      : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM:   Cones                  : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM:   Scalar variables       : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM:   Matrix variables       : 1 (scalarized: 545490)\n",
+      "(CVXPY) May 25 03:45:15 PM:   Integer variables      : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM: \n",
+      "(CVXPY) May 25 03:45:15 PM: Optimizer started.\n",
+      "(CVXPY) May 25 03:45:15 PM: Presolve started.\n",
+      "(CVXPY) May 25 03:45:15 PM: Linear dependency checker started.\n",
+      "(CVXPY) May 25 03:45:15 PM: Linear dependency checker terminated.\n",
+      "(CVXPY) May 25 03:45:15 PM: Eliminator started.\n",
+      "(CVXPY) May 25 03:45:15 PM: Freed constraints in eliminator : 0\n",
+      "(CVXPY) May 25 03:45:15 PM: Eliminator terminated.\n",
+      "(CVXPY) May 25 03:45:15 PM: Eliminator - tries                  : 1                 time                   : 0.00            \n",
+      "(CVXPY) May 25 03:45:15 PM: Lin. dep.  - tries                  : 1                 time                   : 0.00            \n",
+      "(CVXPY) May 25 03:45:15 PM: Lin. dep.  - primal attempts        : 1                 successes              : 1               \n",
+      "(CVXPY) May 25 03:45:15 PM: Lin. dep.  - dual attempts          : 0                 successes              : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM: Lin. dep.  - primal deps.           : 0                 dual deps.             : 0               \n",
+      "(CVXPY) May 25 03:45:15 PM: Presolve terminated. Time: 0.01    \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - threads                : 8               \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - solved problem         : the primal      \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - Constraints            : 1044            \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - Cones                  : 0               \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - Scalar variables       : 0                 conic                  : 0               \n",
+      "(CVXPY) May 25 03:45:18 PM: Optimizer  - Semi-definite variables: 1                 scalarized             : 545490          \n",
+      "(CVXPY) May 25 03:45:18 PM: Factor     - setup time             : 1.00            \n",
+      "(CVXPY) May 25 03:45:18 PM: Factor     - dense det. time        : 0.00              GP order time          : 0.00            \n",
+      "(CVXPY) May 25 03:45:18 PM: Factor     - nonzeros before factor : 5.45e+05          after factor           : 5.45e+05        \n",
+      "(CVXPY) May 25 03:45:18 PM: Factor     - dense dim.             : 0                 flops                  : 1.54e+12        \n",
+      "(CVXPY) May 25 03:45:18 PM: ITE PFEAS    DFEAS    GFEAS    PRSTATUS   POBJ              DOBJ              MU       TIME  \n",
+      "(CVXPY) May 25 03:45:18 PM: 0   1.7e+00  1.0e+00  1.0e+00  0.00e+00   1.044000000e-03   -0.000000000e+00  1.0e+00  3.03  \n",
+      "(CVXPY) May 25 03:45:39 PM: 1   1.5e+00  8.9e-01  8.4e-01  9.99e-01   9.127622043e-04   -0.000000000e+00  8.9e-01  24.14 \n",
+      "(CVXPY) May 25 03:46:04 PM: 2   1.1e+00  6.5e-01  5.2e-01  9.99e-01   7.418852904e-04   -0.000000000e+00  6.5e-01  49.32 \n",
+      "(CVXPY) May 25 03:46:32 PM: 3   5.7e-01  3.3e-01  1.9e-01  9.99e-01   6.338006132e-04   -0.000000000e+00  3.3e-01  76.37 \n",
+      "(CVXPY) May 25 03:47:01 PM: 4   1.8e-01  1.1e-01  3.5e-02  9.97e-01   5.559286057e-04   -0.000000000e+00  1.1e-01  105.62\n",
+      "(CVXPY) May 25 03:47:29 PM: 5   1.5e-01  8.5e-02  2.5e-02  9.90e-01   6.573504301e-04   -0.000000000e+00  8.5e-02  133.83\n",
+      "(CVXPY) May 25 03:47:58 PM: 6   8.7e-02  5.1e-02  1.2e-02  9.83e-01   8.116350312e-04   -0.000000000e+00  5.1e-02  162.65\n",
+      "(CVXPY) May 25 03:48:31 PM: 7   6.9e-03  4.0e-03  2.9e-04  9.65e-01   1.014275395e-03   -0.000000000e+00  4.0e-03  196.26\n",
+      "(CVXPY) May 25 03:49:01 PM: 8   3.2e-03  1.9e-03  1.2e-04  5.90e-01   1.384938473e-03   -0.000000000e+00  1.9e-03  226.08\n",
+      "(CVXPY) May 25 03:49:41 PM: 9   2.8e-04  1.6e-04  1.0e-05  2.90e-01   3.309079387e-03   -0.000000000e+00  1.6e-04  265.52\n",
+      "(CVXPY) May 25 03:50:18 PM: 10  1.3e-04  7.3e-05  5.7e-06  -6.42e-01  5.651502410e-03   -0.000000000e+00  7.3e-05  303.00\n",
+      "(CVXPY) May 25 03:50:55 PM: 11  7.4e-05  4.3e-05  3.4e-06  -2.55e-01  5.863253249e-03   -0.000000000e+00  4.3e-05  340.30\n",
+      "(CVXPY) May 25 03:51:34 PM: 12  5.8e-05  3.4e-05  3.0e-06  -5.15e-01  7.508182960e-03   -0.000000000e+00  3.4e-05  378.89\n",
+      "(CVXPY) May 25 03:52:17 PM: 13  9.5e-06  5.5e-06  6.6e-07  -2.97e-01  1.429839222e-02   -0.000000000e+00  5.5e-06  421.77\n",
+      "(CVXPY) May 25 03:52:52 PM: 14  5.8e-06  3.3e-06  3.6e-07  1.13e-01   1.198274314e-02   -0.000000000e+00  3.3e-06  457.18\n",
+      "(CVXPY) May 25 03:53:30 PM: 15  5.1e-07  2.7e-07  1.6e-08  3.38e-01   3.671506052e-03   -0.000000000e+00  2.7e-07  494.64\n",
+      "(CVXPY) May 25 03:54:01 PM: 16  7.4e-09  1.7e-09  6.0e-12  9.28e-01   1.482313522e-05   -0.000000000e+00  1.6e-09  525.42\n",
+      "(CVXPY) May 25 03:54:33 PM: 17  7.3e-14  1.7e-12  9.8e-25  9.99e-01   3.348505054e-12   -0.000000000e+00  3.5e-16  558.11\n",
+      "(CVXPY) May 25 03:54:33 PM: Optimizer terminated. Time: 558.18  \n",
+      "(CVXPY) May 25 03:54:33 PM: \n",
+      "(CVXPY) May 25 03:54:33 PM: \n",
+      "(CVXPY) May 25 03:54:33 PM: Interior-point solution summary\n",
+      "(CVXPY) May 25 03:54:33 PM:   Problem status  : PRIMAL_AND_DUAL_FEASIBLE\n",
+      "(CVXPY) May 25 03:54:33 PM:   Solution status : OPTIMAL\n",
+      "(CVXPY) May 25 03:54:33 PM:   Primal.  obj: 3.3485050536e-12    nrm: 1e-08    Viol.  con: 7e-14    barvar: 0e+00  \n",
+      "(CVXPY) May 25 03:54:33 PM:   Dual.    obj: 0.0000000000e+00    nrm: 1e+04    Viol.  con: 0e+00    barvar: 1e-10  \n",
+      "(CVXPY) May 25 03:54:34 PM: Problem status: optimal\n",
+      "(CVXPY) May 25 03:54:34 PM: Optimal value: 0.000e+00\n",
+      "(CVXPY) May 25 03:54:34 PM: Compilation took 5.720e+00 seconds\n",
+      "(CVXPY) May 25 03:54:34 PM: Solver (including time spent in interface) took 5.585e+02 seconds\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------\n",
+      "                                    Summary                                    \n",
+      "-------------------------------------------------------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cvxpy as cp\n",
+    "\n",
+    "epsilon = 1e-6 \n",
+    "\n",
+    "# 1. Define decision variables\n",
+    "m = cp.Variable(ndof, complex=True)\n",
+    "\n",
+    "# 2. Construct the Hermitian constraint operator\n",
+    "A = cp.multiply(cp.conj(m)[:, None], U_sym)\n",
+    "H = 0.5j * (A.H - A)\n",
+    "\n",
+    "# 3. Formulate the strict interior constraint\n",
+    "constraints = [H >> epsilon * np.eye(ndof)]\n",
+    "\n",
+    "objective = cp.Minimize(0)  # pure feasibility objective\n",
+    "prob = cp.Problem(objective, constraints)\n",
+    "\n",
+    "# 4. Solve\n",
+    "prob.solve(solver=cp.MOSEK, verbose=True)\n",
+    "\n",
+    "if prob.status not in [\"optimal\", \"optimal_inaccurate\"]:\n",
+    "    raise ValueError(f\"Feasibility search failed. Status: {prob.status}\")\n",
+    "\n",
+    "m_start = m.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Precomputed 1044 A matrices and Fs vectors.\n",
+      "Built the sparse local photonics problem\n",
+      "local_qcqp_type = SparseSharedProjQCQP\n",
+      "current_lags.shape = (1044,)\n",
+      "local_feasible = True\n"
+     ]
+    }
+   ],
+   "source": [
+    "ei_des_local = Ei_sector[des_mask_polar_sector.flatten(order=\"F\")]\n",
+    "\n",
+    "lossless_local = photonics.Photonics_TM_FDFD(\n",
+    "    omega,\n",
+    "    geo_polar,\n",
+    "    chi,\n",
+    "    des_mask_polar_sector,\n",
+    "    J,\n",
+    "    sparseQCQP=True,\n",
+    " )\n",
+    "\n",
+    "A0_local = sp.csc_array((ndof, ndof), dtype=complex)\n",
+    "s0_local = -0.25j * omega * ei_des_local.conj()\n",
+    "lossless_local.set_objective(\n",
+    "    A0=A0_local,\n",
+    "    s0=s0_local,\n",
+    "    c0=LDOS_vac,\n",
+    "    denseToSparse=True,\n",
+    " )\n",
+    "lossless_local.setup_QCQP(Pdiags=\"local\", verbose=1)\n",
+    "\n",
+    "local_lags = np.concatenate([-m_start.imag, -m_start.real])\n",
+    "lossless_local.QCQP.current_lags = local_lags\n",
+    "\n",
+    "A_probe = np.diag(np.conj(m_start)) @ U_sym\n",
+    "H_direct = 0.5j * (A_probe.conj().T - A_probe)\n",
+    "local_feasible = lossless_local.QCQP.is_dual_feasible(local_lags)\n",
+    "\n",
+    "assert local_feasible\n",
+    "\n",
+    "print(\"Built the sparse local photonics problem\")\n",
+    "print(\"local_qcqp_type =\", type(lossless_local.QCQP).__name__)\n",
+    "print(\"current_lags.shape =\", lossless_local.QCQP.current_lags.shape)\n",
+    "print(\"local_feasible =\", local_feasible)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Precomputed 1 A matrices and Fs vectors.\n",
+      "At GCD iteration #1, best dual bound found is             28851743.77130631.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/alessio/code/good_code/dolphindes/dolphindes/cvxopt/qcqp.py:178: CholmodTypeConversionWarning: array contains 64 bit integers; but 32 bit integers are needed; slowing down due to converting\n",
+      "  self.Acho.cholesky_inplace(A)\n",
+      "/home/alessio/code/good_code/dolphindes/dolphindes/cvxopt/qcqp.py:216: CholmodTypeConversionWarning: array contains 64 bit integers; but 32 bit integers are needed; slowing down due to converting\n",
+      "  tmp = self.Acho.cholesky(A)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At GCD iteration #2, best dual bound found is             7813101.563035918.\n",
+      "At GCD iteration #3, best dual bound found is             2194298.6474413467.\n",
+      "At GCD iteration #4, best dual bound found is             2191753.2711021076.\n",
+      "At GCD iteration #5, best dual bound found is             1898214.928387576.\n",
+      "At GCD iteration #6, best dual bound found is             1895373.8034333086.\n",
+      "At GCD iteration #7, best dual bound found is             1887108.5754437689.\n",
+      "At GCD iteration #8, best dual bound found is             1869537.922667733.\n",
+      "At GCD iteration #9, best dual bound found is             1841122.0430071955.\n",
+      "At GCD iteration #10, best dual bound found is             1808347.3157625599.\n",
+      "At GCD iteration #11, best dual bound found is             1803722.0160529506.\n",
+      "At GCD iteration #12, best dual bound found is             1772975.6827464176.\n",
+      "At GCD iteration #13, best dual bound found is             1767842.7126624824.\n",
+      "At GCD iteration #14, best dual bound found is             1740461.9098030748.\n",
+      "At GCD iteration #15, best dual bound found is             1740598.5429997914.\n",
+      "At GCD iteration #16, best dual bound found is             1740932.5473270707.\n",
+      "At GCD iteration #17, best dual bound found is             1740729.3033871958.\n",
+      "At GCD iteration #18, best dual bound found is             1740654.5844473185.\n",
+      "At GCD iteration #19, best dual bound found is             1740537.221253756.\n",
+      "At GCD iteration #20, best dual bound found is             1740563.3618830063.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if SOLVE_LOCAL:\n",
+    "    solution = lossless_local.solve_current_dual_problem(method='newton')\n",
+    "\n",
+    "    opt_params = OptimizationHyperparameters(\n",
+    "        opttol = 1e-4,\n",
+    "        gradConverge = True,\n",
+    "        min_inner_iter = 5,\n",
+    "        max_restart = np.inf,\n",
+    "        penalty_ratio = 1e-2,\n",
+    "        penalty_reduction = 0.1,\n",
+    "        break_iter_period = 50,\n",
+    "        verbose = 0\n",
+    "    )\n",
+    "else:\n",
+    "    gcd_params = gcd.GCDHyperparameters(\n",
+    "        max_proj_cstrt_num=8,\n",
+    "        orthonormalize=True,\n",
+    "        opt_params=None,\n",
+    "        gcd_tol=1e-3,\n",
+    "    )\n",
+    "\n",
+    "    gcd.merge_lead_constraints(lossless_local.QCQP, merged_num=np.inf)\n",
+    "    solution = lossless_local.QCQP.run_gcd(gcd_params=gcd_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(2205067.2530000056)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lossless_local.QCQP.current_dual / LDOS_vac"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "test_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_polar_photonics.py
+++ b/tests/test_polar_photonics.py
@@ -131,6 +131,63 @@ class TestPhotonicsTMFDFDPolar:
         assert problem.QCQP is not None
         assert problem.Ndes == setup["Ndes"]
 
+    def test_setup_qcqp_local_dense(self):
+        """Test dense QCQP setup with local one-hot projectors."""
+        wavelength = 1.0
+        omega = 2 * np.pi / wavelength
+        chi = 3 + 1e-2j
+
+        dr = 0.25
+        Nr = 8
+        Nphi = 4
+        Npml = 1
+        n_sectors = 1
+
+        geometry = PolarFDFDGeometry(
+            Nphi=Nphi,
+            Nr=Nr,
+            Npml=Npml,
+            dr=dr,
+            n_sectors=n_sectors,
+            bloch_phase=0.0,
+        )
+
+        des_mask = np.zeros((Nr, Nphi), dtype=bool)
+        des_mask[2:4, :] = True
+        Ndes = int(np.sum(des_mask))
+
+        r_grid = (np.arange(Nr) + 0.5) * dr
+        area_r = r_grid * dr * (2 * np.pi / n_sectors / Nphi)
+        area_vec = np.kron(np.ones(Nphi), area_r)
+
+        ji = np.zeros(Nr * Nphi, dtype=complex)
+        ji[1] = 1.0 / area_vec[1]
+
+        problem = Photonics_TM_FDFD(
+            omega=omega,
+            geometry=geometry,
+            chi=chi,
+            des_mask=des_mask,
+            ji=ji,
+            sparseQCQP=False,
+        )
+        problem.get_ei(ji, update=True)
+        problem.set_objective(
+            A0=sp.csc_array((Ndes, Ndes), dtype=complex),
+            s0=np.zeros(Ndes, dtype=complex),
+            c0=0.0,
+            denseToSparse=False,
+        )
+        problem.setup_QCQP(Pdiags="local")
+
+        assert problem.QCQP is not None
+        assert problem.Plist is not None
+        assert problem.QCQP.n_proj_constr == 2 * Ndes
+        assert len(problem.Plist) == 2 * Ndes
+        assert problem.QCQP.Proj.Pdiags.shape == (Ndes, 2 * Ndes)
+        assert np.allclose(problem.QCQP.Proj.Pdiags[:, :Ndes], np.eye(Ndes))
+        assert np.allclose(problem.QCQP.Proj.Pdiags[:, Ndes:], -1j * np.eye(Ndes))
+
     def test_bound_qcqp(self, absorption_problem_setup):
         """Test that QCQP bound can be computed."""
         setup = absorption_problem_setup


### PR DESCRIPTION
This pull request adds some functionality to Dolphindes:
1. GCD merge_lead_constraints can now take inf or np.inf as an argument to merge all constraints into one
2. The photonics QCQP builder can now build "local" projectors by default.

This PR also adds a notebook that formulates a feasibility problem (for only linear objectives) in cvxpy and solves it with MOSEK, bypassing the requirement for an explicit PSD or PD constraint. The theory for this is not published anywhere yet, but a reference will be added at some point. Regardless, it does work: MOSEK can find a feasible point (at least for the test LDOS enhancement problem) which can then be input into the dual solver to find limits on problems where the structure has zero loss (and the source has zero bandwidth). In principle, it should also be able to output a certificate of infeasibility if that were the case. Theoretical constraints: chi must be finite and the design domain must be finite size.