### PR TITLE
CI: build the PyPI distribution on every PR/push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: "CI: Build"
+
+# Builds the sdist and wheel and runs packaging checks. Runs on every PR/push
+# as a CI check, and is called by publish.yml on release (via workflow_call) so
+# the exact same build that ships to PyPI is validated before a release exists.
+on:
+  workflow_call:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+      - name: Verify the wheel ships every subpackage
+        run: |
+          python -m venv /tmp/whlcheck
+          /tmp/whlcheck/bin/pip install --no-deps dist/*.whl
+          /tmp/whlcheck/bin/python - <<'PY'
+          import importlib.util as u
+          mods = ["dolphindes", "dolphindes.photonics", "dolphindes.maxwell",
+                  "dolphindes.cvxopt", "dolphindes.geometry", "dolphindes.util"]
+          missing = [m for m in mods if u.find_spec(m) is None]
+          assert not missing, f"built wheel is missing subpackages: {missing}"
+          print("wheel contains all subpackages:", mods)
+          PY
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,35 +8,9 @@ on:
 
 jobs:
   build:
-    name: Build distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-      - name: Build sdist and wheel
-        run: |
-          python -m pip install --upgrade build twine
-          python -m build
-          python -m twine check dist/*
-      - name: Verify the wheel ships every subpackage
-        run: |
-          python -m venv /tmp/whlcheck
-          /tmp/whlcheck/bin/pip install --no-deps dist/*.whl
-          /tmp/whlcheck/bin/python - <<'PY'
-          import importlib.util as u
-          mods = ["dolphindes", "dolphindes.photonics", "dolphindes.maxwell",
-                  "dolphindes.cvxopt", "dolphindes.geometry", "dolphindes.util"]
-          missing = [m for m in mods if u.find_spec(m) is None]
-          assert not missing, f"built wheel is missing subpackages: {missing}"
-          print("wheel contains all subpackages:", mods)
-          PY
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
+    # Reuse the exact build that runs on every CI check (see build.yml) so the
+    # release ships precisely what was already validated on the merged commit.
+    uses: ./.github/workflows/build.yml
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
## What

Extracts the packaging **build** job out of `publish.yml` into a reusable workflow, **`build.yml`**, that:

- runs on every `pull_request` / `push` to `main` as a CI check, **and**
- is invoked by `publish.yml` on release via `workflow_call`.

`publish.yml`'s `build` job is now a one-liner: `uses: ./.github/workflows/build.yml`. The privileged `publish` job is unchanged and still just downloads the `dist` artifact and uploads it via Trusted Publishing (OIDC).

## Why

Today the sdist/wheel build, `twine check`, and subpackage-verification only run when a release is published. If any of that breaks, we find out *at publish time* — and since the release already exists, retrying means cutting another release. Running the identical build during CI catches packaging breakage on the PR that introduced it.

Because release and CI now share one build definition, a release provably ships exactly what CI validated — no drift between the two.

## Notes

- No double-runs: `release` doesn't trigger `pull_request`/`push`, and `workflow_call` is only used when `publish.yml` invokes it.
- Artifacts uploaded inside the reusable workflow remain in the same run, so `publish`'s `download-artifact` still finds `dist`.
- The `dist` artifact is now also produced on PR/push runs (handy for inspecting a built wheel); harmless otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)