### PR TITLE
factorization re-use and tests.

### DIFF
--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, cast
 
 import numpy as np
@@ -190,6 +190,17 @@ class _SharedProjQCQP(ABC):
         self.current_xstar: Optional[ComplexArray] = None
         self.use_precomp = True
 
+        # Cache of recently computed Cholesky factorizations, keyed by the lags
+        # they correspond to. During dual optimization the same A(lags) is often
+        # factorized several times in a row (the line-search feasibility check
+        # followed by the objective evaluation at the same point, and the accepted
+        # step re-evaluated at the start of the next iteration). Reusing the
+        # factorization in those cases avoids the dominant cost of get_dual.
+        # A size of 2 is enough to catch both redundancies (see _get_factorization)
+        # while keeping at most two (large) factorizations in memory.
+        self._factor_cache: "OrderedDict[bytes, Tuple[Any, Any]]" = OrderedDict()
+        self._factor_cache_maxsize = 2
+
         if self.use_precomp:
             self.compute_precomputed_values()
 
@@ -208,6 +219,10 @@ class _SharedProjQCQP(ABC):
         This speeds up repeated assembly of A(lags) and derivative-related
         operations when the number of constraints is moderate.
         """
+        # The constraint matrices are being rebuilt, so any cached factorization
+        # (keyed by lags, but implicitly tied to the current A_k) is now stale.
+        self._invalidate_factor_cache()
+
         self.precomputed_As = []
         for i in range(self.n_proj_constr):
             Ak = Sym(self.A1 @ self.Proj[i] @ self.A2)
@@ -301,17 +316,83 @@ class _SharedProjQCQP(ABC):
         """Return Σ_general μ_j c_2j (0 if no general constraints)."""
         return cast(float, np.sum(lags[self.n_proj_constr :] * self.c_2j))
 
-    @abstractmethod
-    def _update_Acho(self, A: sp.csc_array | ComplexArray) -> None:
-        """
-        Update the Cholesky factorization to be that of the input matrix A.
+    @staticmethod
+    def _lags_key(lags: FloatNDArray) -> bytes:
+        """Return a hashable, value-based key identifying a lags vector.
 
-        Needs to be implemented by subclasses.
+        Two lags arrays with identical float64 values map to the same key, so a
+        factorization computed for one call is reused for the next call at the
+        same point regardless of which array object carried it.
+        """
+        return np.ascontiguousarray(lags, dtype=np.float64).tobytes()
+
+    def _invalidate_factor_cache(self) -> None:
+        """Drop all cached factorizations.
+
+        Must be called whenever A(lags) changes for a fixed lags, i.e. whenever
+        A0, precomputed_As or the constraint set are modified.
+        """
+        self._factor_cache.clear()
+
+    def _store_factor(self, key: bytes, A: Any, factor: Any) -> None:
+        """Record (A, factor) for ``key`` and mark it the active factorization.
+
+        Evicts least-recently-used entries beyond ``_factor_cache_maxsize``.
+        Setting ``self.Acho`` keeps the penalty/Hessian solves in get_dual, which
+        operate through ``_Acho_solve`` on the current factor, consistent.
+        """
+        self.Acho = factor
+        self._factor_cache[key] = (A, factor)
+        self._factor_cache.move_to_end(key)
+        while len(self._factor_cache) > self._factor_cache_maxsize:
+            self._factor_cache.popitem(last=False)
+
+    def _get_factorization(self, lags: FloatNDArray) -> Tuple[Any, Any]:
+        """Return (A, factor) for ``lags``, reusing a cached factorization if any.
+
+        On a cache miss, A(lags) is assembled and factorized; on a hit, both the
+        assembly and the (dominant) Cholesky factorization are skipped. Either
+        way ``self.Acho`` is set to the returned factor.
+
+        A cache of size 2 removes the two redundant factorizations that arise per
+        line-search step: (1) the feasibility check at a point immediately
+        followed by the objective evaluation at the same point, and (2) the
+        accepted step, which is the second-to-last point tried during
+        backtracking and is re-evaluated at the start of the next iteration.
+        """
+        key = self._lags_key(lags)
+        cached = self._factor_cache.get(key)
+        if cached is not None:
+            A, factor = cached
+            self._factor_cache.move_to_end(key)
+            self.Acho = factor
+            return A, factor
+
+        A = self._get_total_A(lags)
+        factor = self._factorize(A)
+        self._store_factor(key, A, factor)
+        return A, factor
+
+    @abstractmethod
+    def _factorize(self, A: sp.csc_array | ComplexArray) -> Any:
+        """
+        Return a new Cholesky factorization object of the Hermitian PD matrix A.
+
+        Unlike an in-place update, this returns a distinct factor object so that
+        several factorizations can be cached simultaneously. Needs to be
+        implemented by subclasses.
 
         Parameters
         ----------
         A : sp.csc_array | ComplexArray
-            New total Hermitian matrix to factorize (or store for dense solve).
+            Hermitian positive (semi)definite matrix to factorize.
+
+        Returns
+        -------
+        Any
+            An opaque factorization object accepted by ``_Acho_solve`` (a
+            sksparse CHOLMOD Factor for sparse, a scipy cho_factor tuple for
+            dense).
         """
         pass
 
@@ -432,9 +513,8 @@ class _SharedProjQCQP(ABC):
         xAx : float
             Value x*^† A x* (real scalar).
         """
-        A = self._get_total_A(lags)
+        A, _factor = self._get_factorization(lags)
         S = self._get_total_S(lags)
-        self._update_Acho(A)
         x_star: ComplexArray = self._Acho_solve(S)
         xAx: float = np.real(np.vdot(x_star, A @ x_star))
 

--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -61,7 +61,9 @@ class _SharedProjQCQP(ABC):
     verbose : int
         Verbosity level (0 = silent).
     Acho : Any | None
-        Cholesky (or other) factorization object of the current total A matrix.
+        Most recent numeric factorization object (of the last A(lags) that was
+        factorized), set by ``_store_factor``/``_get_factorization`` and used by
+        ``_Acho_solve``. ``None`` until the first factorization.
     current_dual : float | None
         Cached dual value after solve_current_dual_problem().
     current_lags : FloatNDArray | None

--- a/dolphindes/cvxopt/gcd.py
+++ b/dolphindes/cvxopt/gcd.py
@@ -113,6 +113,9 @@ def merge_lead_constraints(QCQP: _SharedProjQCQP, merged_num: int = 2) -> None:
 
     QCQP.current_grad = QCQP.current_hess = None
 
+    # precomputed_As/Fs were edited in place, so cached factorizations are stale.
+    QCQP._invalidate_factor_cache()
+
 
 def add_constraints(
     QCQP: _SharedProjQCQP,
@@ -185,6 +188,9 @@ def add_constraints(
 
     QCQP.n_proj_constr = len(QCQP.Proj)
     QCQP.current_grad = QCQP.current_hess = None
+
+    # precomputed_As/Fs were edited in place, so cached factorizations are stale.
+    QCQP._invalidate_factor_cache()
 
 
 def run_gcd(

--- a/dolphindes/cvxopt/qcqp.py
+++ b/dolphindes/cvxopt/qcqp.py
@@ -9,6 +9,7 @@ implementations optimized for different matrix structures.
 __all__ = ["SparseSharedProjQCQP", "DenseSharedProjQCQP"]
 
 import copy
+from collections import OrderedDict
 from typing import Any, cast
 
 import numpy as np
@@ -127,14 +128,16 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "SparseSharedProjQCQP":
         """Copy this instance."""
-        # custom __deepcopy__ because Acho is not pickle-able
+        # custom __deepcopy__ because the CHOLMOD factorizations (the symbolic
+        # analysis and the cached numeric factors) are not pickle-able.
+        skip = {"Acho", "_Acho_symbolic", "_factor_cache"}
         new_QCQP = SparseSharedProjQCQP.__new__(SparseSharedProjQCQP)
         for name, value in self.__dict__.items():
-            if name != "Acho":
+            if name not in skip:
                 setattr(new_QCQP, name, copy.deepcopy(value, memo))
 
-        new_QCQP._initialize_Acho()  # Recompute the Cholesky factorization.
-        # If dense, will use self.current_lags.
+        new_QCQP._factor_cache = OrderedDict()  # start with an empty factor cache
+        new_QCQP._initialize_Acho()  # Recompute the symbolic Cholesky analysis.
         # TODO: update Acho with current_lags if applicable
         return new_QCQP
 
@@ -147,10 +150,15 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
         """
         Symbolically analyze sparsity/fill pattern for Cholesky factorization.
 
+        The symbolic analysis is stored in ``self._Acho_symbolic`` and reused by
+        every subsequent numeric factorization (which only needs the shared
+        sparsity pattern). ``self.Acho`` holds the most recent numeric factor and
+        is reset here since no numeric factorization has been computed yet.
+
         Returns
         -------
         sksparse.cholmod.Factor
-            Analyzed (symbolic) factorization handle stored in self.Acho.
+            Analyzed (symbolic) factorization handle (``self._Acho_symbolic``).
         """
         random_lags = np.random.rand(self.n_proj_constr + self.n_gen_constr)
         A = self._get_total_A(random_lags)
@@ -162,20 +170,29 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
                 f"analyzing A of format and shape {type(A)}, {A.shape} "
                 f"and # of nonzero elements '{A.nnz}"
             )
-        self.Acho = sksparse.cholmod.analyze(A)
-        return self.Acho
+        self._Acho_symbolic: sksparse.cholmod.Factor = sksparse.cholmod.analyze(A)
+        self.Acho = None
+        return self._Acho_symbolic
 
-    def _update_Acho(self, A: sp.csc_array) -> None:
+    def _factorize(self, A: sp.csc_array) -> sksparse.cholmod.Factor:
         """
-        Update numerical Cholesky factorization for total matrix A.
+        Return a fresh numeric Cholesky factor of A, reusing the symbolic analysis.
+
+        ``Factor.cholesky`` (unlike ``cholesky_inplace``) returns a new factor
+        object, so distinct factorizations can coexist in the factor cache.
 
         Parameters
         ----------
         A : sp.csc_array
             Current Hermitian (PSD / PD) system matrix.
+
+        Returns
+        -------
+        sksparse.cholmod.Factor
+            Numeric factorization of A.
         """
-        assert self.Acho is not None
-        self.Acho.cholesky_inplace(A)
+        assert self._Acho_symbolic is not None
+        return self._Acho_symbolic.cholesky(sp.csc_array(A))
 
     def _Acho_solve(self, b: ComplexArray) -> ComplexArray:
         """
@@ -208,18 +225,25 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
         bool
             True if factorization succeeds (A is PSD), False otherwise.
         """
-        assert self.Acho is not None
+        assert self._Acho_symbolic is not None
+        key = self._lags_key(lags)
+        if key in self._factor_cache:
+            # A(lags) was already factorized successfully -> positive definite.
+            return True
         A = self._get_total_A(lags)
         assert sp.issparse(A)
         A = sp.csc_array(A)
         try:
-            tmp = self.Acho.cholesky(A)
-            tmp = (
-                tmp.L()
-            )  # Have to access the factor for the decomposition to be actually done.
-            return True
+            factor = self._factorize(A)
+            # Accessing the factor forces the numeric decomposition to run, so a
+            # non-PD matrix raises here rather than lazily at solve time.
+            factor.L()
         except sksparse.cholmod.CholmodNotPositiveDefiniteError:
             return False
+        # Feasible: cache the factor so the imminent get_dual at the same lags
+        # (line-search objective evaluation) reuses it instead of refactorizing.
+        self._store_factor(key, A, factor)
+        return True
 
 
 class DenseSharedProjQCQP(_SharedProjQCQP):
@@ -294,16 +318,21 @@ class DenseSharedProjQCQP(_SharedProjQCQP):
             f"{self.n_proj_constr} projectors."
         )
 
-    def _update_Acho(self, A: ArrayLike) -> None:
+    def _factorize(self, A: ArrayLike) -> Any:
         """
-        Update dense Cholesky factorization of A.
+        Return a dense Cholesky factorization (cho_factor tuple) of A.
 
         Parameters
         ----------
         A : ArrayLike
             Hermitian positive (semi)definite matrix to factor.
+
+        Returns
+        -------
+        Any
+            The ``scipy.linalg.cho_factor`` result ``(c, lower)``.
         """
-        self.Acho = la.cho_factor(A)
+        return la.cho_factor(A)
 
     def _Acho_solve(self, b: ComplexArray) -> ComplexArray:
         """
@@ -335,9 +364,16 @@ class DenseSharedProjQCQP(_SharedProjQCQP):
         bool
             True if Cholesky succeeds, False otherwise.
         """
+        key = self._lags_key(lags)
+        if key in self._factor_cache:
+            # A(lags) was already factorized successfully -> positive definite.
+            return True
         A = self._get_total_A(lags)
         try:
-            la.cho_factor(A)
-            return True
+            factor = self._factorize(A)
         except la.LinAlgError:
             return False
+        # Feasible: cache the factor so the imminent get_dual at the same lags
+        # (line-search objective evaluation) reuses it instead of refactorizing.
+        self._store_factor(key, A, factor)
+        return True

--- a/dolphindes/cvxopt/qcqp.py
+++ b/dolphindes/cvxopt/qcqp.py
@@ -91,7 +91,9 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
     Fs : ComplexArray
         Columns are A2^† P_j^† s1 (projector-only part used in derivatives).
     Acho : sksparse.cholmod.Factor | None
-        Symbolic/numeric CHOLMOD factorization handle (updated per solve).
+        Most recent numeric CHOLMOD factor (``None`` until the first
+        factorization). The symbolic analysis is held separately in
+        ``_Acho_symbolic`` and reused across factorizations.
     current_dual : float | None
         Cached optimal dual value after solve_current_dual_problem().
     current_lags : FloatNDArray | None
@@ -118,6 +120,11 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
     DenseSharedProjQCQP : Dense analogue using LAPACK factorization.
     _SharedProjQCQP    : Base abstract class with core logic.
     """
+
+    # Symbolic CHOLMOD analysis (sparsity/fill pattern), computed once by
+    # _initialize_Acho during construction and reused by every numeric
+    # factorization. Declared here so its type is visible to static checkers.
+    _Acho_symbolic: "sksparse.cholmod.Factor"
 
     def __repr__(self) -> str:
         """Return a concise string summary (size and projector count)."""
@@ -170,7 +177,7 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
                 f"analyzing A of format and shape {type(A)}, {A.shape} "
                 f"and # of nonzero elements '{A.nnz}"
             )
-        self._Acho_symbolic: sksparse.cholmod.Factor = sksparse.cholmod.analyze(A)
+        self._Acho_symbolic = sksparse.cholmod.analyze(A)
         self.Acho = None
         return self._Acho_symbolic
 
@@ -228,7 +235,10 @@ class SparseSharedProjQCQP(_SharedProjQCQP):
         assert self._Acho_symbolic is not None
         key = self._lags_key(lags)
         if key in self._factor_cache:
-            # A(lags) was already factorized successfully -> positive definite.
+            # A(lags) was already factorized successfully -> positive definite
+            # (see the cache invariant in _store_factor). Count the hit as a use
+            # so the entry is not evicted before a genuinely older one.
+            self._factor_cache.move_to_end(key)
             return True
         A = self._get_total_A(lags)
         assert sp.issparse(A)
@@ -366,7 +376,10 @@ class DenseSharedProjQCQP(_SharedProjQCQP):
         """
         key = self._lags_key(lags)
         if key in self._factor_cache:
-            # A(lags) was already factorized successfully -> positive definite.
+            # A(lags) was already factorized successfully -> positive definite
+            # (see the cache invariant in _store_factor). Count the hit as a use
+            # so the entry is not evicted before a genuinely older one.
+            self._factor_cache.move_to_end(key)
             return True
         A = self._get_total_A(lags)
         try:

--- a/tests/test_factorization_cache.py
+++ b/tests/test_factorization_cache.py
@@ -1,0 +1,235 @@
+"""Tests for the QCQP dual factorization cache (issue #12).
+
+The dominant cost of evaluating the QCQP dual is assembling the total matrix
+``A(lags)`` and computing its Cholesky factorization. During dual optimization
+the same ``A(lags)`` is factorized several times in a row -- most notably the
+line-search feasibility check immediately followed by the objective evaluation
+at the same point, and the accepted step, which is re-evaluated at the start of
+the next iteration. ``_SharedProjQCQP`` caches recent factorizations keyed
+by ``lags`` so those repeats are skipped.
+
+These tests verify that caching:
+
+* is transparent: reusing a factorization gives exactly the result a fresh
+  factorization would, and the cache is invalidated whenever ``A(lags)``
+  changes; and
+* actually removes factorizations: a full dual solve performs measurably fewer
+  Cholesky factorizations with the cache enabled.
+
+Setting ``qcqp._factor_cache_maxsize = 0`` disables reuse (every lookup misses),
+reproducing legacy behaviour of refactorizing on every dual evaluation; it
+is used here as the baseline.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from dolphindes.cvxopt import DenseSharedProjQCQP, SparseSharedProjQCQP
+
+
+def _reference_dir(kind: str) -> Path:
+    return (
+        Path(os.path.dirname(__file__))
+        / "reference_arrays"
+        / "qcqp_example"
+        / kind
+        / "global"
+    )
+
+
+def _interleaved_projectors(data_path: Path):
+    """Rebuild the projector list exactly as the main QCQP fixtures do."""
+    projections_diags = np.asarray(
+        np.load(data_path / "ldos_some_projections.npy", allow_pickle=True)
+    )
+    interleaved = np.empty(
+        (2 * projections_diags.shape[0], projections_diags.shape[1]), dtype=complex
+    )
+    interleaved[0::2] = projections_diags
+    interleaved[1::2] = projections_diags * -1j
+    Pdiags = interleaved.T
+    return [sp.diags_array(Pdiags[:, j], format="csc") for j in range(Pdiags.shape[1])]
+
+
+@pytest.fixture
+def sparse_qcqp_builder():
+    """Return a zero-argument factory that builds a fresh SparseSharedProjQCQP."""
+    data_path = _reference_dir("sparse")
+    A0 = sp.csc_array(sp.load_npz(data_path / "ldos_sparse_A0.npz"))
+    A1 = sp.csc_array(sp.load_npz(data_path / "ldos_sparse_A1.npz"))
+    A2 = sp.csc_array(sp.load_npz(data_path / "ldos_sparse_A2.npz"))
+    s0 = np.load(data_path / "ldos_sparse_s0.npy", allow_pickle=True)
+    s1 = np.load(data_path / "ldos_sparse_s1.npy", allow_pickle=True)
+    c = np.load(data_path / "ldos_dualconst.npy", allow_pickle=True)
+    Projlist = _interleaved_projectors(data_path)
+
+    def build():
+        return SparseSharedProjQCQP(
+            A0, s0, c, A1, A2, s1, Projlist, Projlist[0], verbose=0
+        )
+
+    return build
+
+
+@pytest.fixture
+def dense_qcqp_builder():
+    """Return a zero-argument factory that builds a fresh DenseSharedProjQCQP."""
+    data_path = _reference_dir("dense")
+    A0 = np.load(data_path / "ldos_dense_A0.npy")
+    A1 = np.load(data_path / "ldos_dense_A1.npy")
+    s0 = np.load(data_path / "ldos_dense_s0.npy", allow_pickle=True)
+    s1 = np.load(data_path / "ldos_dense_s1.npy", allow_pickle=True)
+    c = np.load(data_path / "ldos_dualconst.npy", allow_pickle=True)
+    Projlist = _interleaved_projectors(data_path)
+
+    def build():
+        return DenseSharedProjQCQP(
+            A0, s0, c, A1, s1, Projlist, Projlist[0], None, verbose=0
+        )
+
+    return build
+
+
+def _count_factorizations(qcqp):
+    """Patch qcqp._factorize to count invocations; return a mutable counter."""
+    counter = {"n": 0}
+    original = qcqp._factorize
+
+    def counting(A):
+        counter["n"] += 1
+        return original(A)
+
+    qcqp._factorize = counting
+    return counter
+
+
+def _solve_counting(build, method, maxsize, init_lags):
+    """Solve the dual and return (n_factorizations, solve_result)."""
+    np.random.seed(0)
+    qcqp = build()
+    qcqp._factor_cache_maxsize = maxsize
+    qcqp._invalidate_factor_cache()
+    counter = _count_factorizations(qcqp)
+    # Seed again so the ARPACK starting vector in any PSD-penalty eigsh call is
+    # identical between the baseline and cached runs.
+    np.random.seed(0)
+    result = qcqp.solve_current_dual_problem(method, init_lags=init_lags.copy())
+    return counter["n"], result
+
+
+@pytest.mark.parametrize("builder", ["sparse_qcqp_builder", "dense_qcqp_builder"])
+def test_feasibility_check_factorization_is_reused(builder, request):
+    """is_dual_feasible(lags) then get_dual(lags) -> a single factorization.
+
+    This is redundancy #1: the line-search feasibility probe factorizes A(lags),
+    then the objective evaluation at the same point would refactorize it.
+    """
+    qcqp = request.getfixturevalue(builder)()
+    lags = qcqp.find_feasible_lags()
+
+    qcqp._invalidate_factor_cache()
+    counter = _count_factorizations(qcqp)
+
+    assert qcqp.is_dual_feasible(lags)  # factorizes once
+    assert counter["n"] == 1
+    qcqp.get_dual(lags, get_grad=True)
+    assert counter["n"] == 1, "get_dual refactorized after a feasibility check"
+
+
+@pytest.mark.parametrize("builder", ["sparse_qcqp_builder", "dense_qcqp_builder"])
+def test_repeated_get_dual_reuses_factorization(builder, request):
+    """get_dual(lags) twice at the same lags factorizes only once."""
+    qcqp = request.getfixturevalue(builder)()
+    lags = qcqp.find_feasible_lags()
+
+    qcqp._invalidate_factor_cache()
+    counter = _count_factorizations(qcqp)
+
+    d0 = qcqp.get_dual(lags, get_grad=True, get_hess=True)
+    assert counter["n"] == 1
+    d1 = qcqp.get_dual(lags, get_grad=True, get_hess=True)
+    assert counter["n"] == 1, "second get_dual at the same lags refactorized"
+
+    # Transparency: the reused factorization yields identical dual/grad/hess.
+    assert np.isclose(d0[0], d1[0], rtol=0, atol=0)
+    assert np.array_equal(d0[1], d1[1])
+    assert np.array_equal(d0[2], d1[2])
+
+
+@pytest.mark.parametrize("builder", ["sparse_qcqp_builder", "dense_qcqp_builder"])
+def test_cache_invalidated_when_constraints_change(builder, request):
+    """Rebuilding the constraint data must drop stale cached factorizations."""
+    qcqp = request.getfixturevalue(builder)()
+    lags = qcqp.find_feasible_lags()
+
+    qcqp._invalidate_factor_cache()
+    counter = _count_factorizations(qcqp)
+
+    qcqp.get_dual(lags)
+    assert counter["n"] == 1
+    qcqp.compute_precomputed_values()
+    qcqp.get_dual(lags)
+    assert counter["n"] == 2, "cache was not invalidated by compute_precomputed_values"
+
+
+@pytest.mark.parametrize("builder", ["sparse_qcqp_builder", "dense_qcqp_builder"])
+def test_disabling_cache_refactorizes_every_call(builder, request):
+    """With maxsize=0 (cache disabled), every evaluation refactorizes."""
+    qcqp = request.getfixturevalue(builder)()
+    lags = qcqp.find_feasible_lags()
+
+    qcqp._factor_cache_maxsize = 0
+    qcqp._invalidate_factor_cache()
+    counter = _count_factorizations(qcqp)
+
+    assert qcqp.is_dual_feasible(lags)
+    qcqp.get_dual(lags)
+    qcqp.get_dual(lags)
+    assert counter["n"] == 3, "cache disabled but factorizations were still reused"
+
+
+@pytest.mark.parametrize("method", ["bfgs", "newton"])
+@pytest.mark.parametrize("builder", ["sparse_qcqp_builder", "dense_qcqp_builder"])
+def test_cache_reduces_factorizations_in_full_solve(method, builder, request, capsys):
+    """A full dual solve does strictly fewer factorizations with the cache on.
+
+    Compares a baseline solve (cache disabled) against a cached solve from the
+    same feasible starting point. The result must be unchanged and the number of
+    Cholesky factorizations must drop.
+    """
+    build = request.getfixturevalue(builder)
+
+    np.random.seed(0)
+    init_lags = build().find_feasible_lags()
+
+    base_n, base_res = _solve_counting(build, method, 0, init_lags)
+    cache_n, cache_res = _solve_counting(build, method, 2, init_lags)
+
+    # 1) Caching must not change the optimum. Reusing a factorization is
+    #    bit-identical per evaluation (see the unit tests above); across a full
+    #    solve the two trajectories may differ only by floating-point noise, far
+    #    below the optimizer's own tolerance (opttol=1e-2), so a tight-but-not
+    #    bit-exact tolerance is the meaningful transparency check.
+    assert np.isclose(base_res[0], cache_res[0], rtol=1e-6), (
+        f"dual value changed: {base_res[0]} vs {cache_res[0]}"
+    )
+    assert np.allclose(base_res[1], cache_res[1], rtol=1e-5, atol=1e-8), (
+        "optimal lags changed with caching enabled"
+    )
+
+    # 2) Caching must remove factorizations.
+    reduction = (base_n - cache_n) / base_n
+    kind = "sparse" if "sparse" in builder else "dense"
+    with capsys.disabled():
+        print(
+            f"\n[{kind:6s} {method:6s}] Cholesky factorizations: "
+            f"{base_n} (baseline) -> {cache_n} (cached)  "
+            f"= {100 * reduction:.1f}% fewer"
+        )
+    assert cache_n < base_n, "caching did not reduce the number of factorizations"
+    # Conservative floor.
+    assert reduction >= 0.05


### PR DESCRIPTION
Closes #12 with a cholesky cache. Gives a 10-30% performance improvement in limits by eliminating redundancies in repeating the same lags call to get_dual as well as in the feasibility checker.

The optimizer stays unaware that it's optimizing a QCQP dual. The cache lives entirely inside `_SharedProjQCQP`, so the modularity between the convex-optimization layer and the QCQP layer is preserved (no change to the `optfunc` interface).

