### PR TITLE
3x improvement in sparse bounds speed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ project = "Dolphindes"
 copyright = "2025, DolphinDes contributors"
 author = "DolphinDes contributors"
 # Pull the version from the installed package so it stays in sync with
-# dolphindes/__init__.py 
+# dolphindes/__init__.py
 release = _pkg_version("dolphindes")
 
 # -- General configuration ---------------------------------------------------

--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -559,10 +559,14 @@ class _SharedProjQCQP(ABC):
         xAx : float
             Value x*^† A x* (real scalar).
         """
-        A, _factor = self._get_factorization(lags)
+        # Called for self.Acho, which _Acho_solve reads
+        self._get_factorization(lags)
         S = self._get_total_S(lags)
         x_star: ComplexArray = self._Acho_solve(S)
-        xAx: float = np.real(np.vdot(x_star, A @ x_star))
+
+        # Faster and more accurate than np.real(np.vdot(x_star, A @ x_star)), since
+        # A x* = S.
+        xAx: float = np.real(np.vdot(x_star, S))
 
         return x_star, xAx
 

--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -302,7 +302,7 @@ class _SharedProjQCQP(ABC):
         """Return total A using precomputed_As.
 
         Assembles on the fixed pattern when one is available (see
-        ``_build_assembly_map``), otherwise sums the A_k elmentwise.
+        ``_build_assembly_map``), otherwise sums the A_k elementwise.
         """
         if not self._assembly_map_built:
             self._assembly_map = self._build_assembly_map()
@@ -320,16 +320,16 @@ class _SharedProjQCQP(ABC):
     ) -> Optional[Tuple[Any, Any, Tuple[int, int], ComplexArray, ComplexArray]]:
         """Return a fixed-pattern representation of A(lags), or None if unavailable.
 
-        Every A_k is supported inside one lags-independent pattern so A(lags) needs no 
-        index merging at all. Holding each A_k's entries in their slots in that pattern 
+        Every A_k is supported inside one lags-independent pattern so A(lags) needs no
+        index merging at all. Holding each A_k's entries in their slots in that pattern
         as the columns of a dense ``(nnz, n_constr)`` block D,
 
             A(lags).data = a0 + D @ lags
 
         which is one operation over contiguous memory in place of ``n_constr`` sparse
-        additions that each merge two index structures and allocate. 
+        additions that each merge two index structures and allocate.
 
-        Returns None (leaving the elmentwise sum in use) when the formulation is
+        Returns None (leaving the elementwise sum in use) when the formulation is
         dense, where the A_k are full n^2 matrices with no pattern to share, or when
         D would exceed ``_assembly_map_max_bytes``.
 
@@ -343,7 +343,14 @@ class _SharedProjQCQP(ABC):
 
         mats = [sp.csc_array(self.A0)] + [sp.csc_array(a) for a in self.precomputed_As]
         for m in mats:
+            # sort_indices orders but does not coalesce; duplicate (i, j) entries would
+            # make the scatter below keep only the last one, silently disagreeing with
+            # the elementwise sum.
+            m.sum_duplicates()
             m.sort_indices()
+
+        # A0 keeps whatever dtype it was given on the sparse path
+        dtype = np.result_type(*[m.dtype for m in mats], np.float64)
 
         def pattern(m: sp.csc_array) -> sp.csc_array:
             ones = m.copy()
@@ -357,14 +364,14 @@ class _SharedProjQCQP(ABC):
         union.sort_indices()
 
         nnz = union.nnz
-        if nnz * len(self.precomputed_As) * 16 > self._assembly_map_max_bytes:
+        if nnz * len(mats[1:]) * dtype.itemsize > self._assembly_map_max_bytes:
             return None
 
         slot_carrier = union.copy()
         slot_carrier.data = np.arange(1, nnz + 1, dtype=float)
 
-        a0 = np.zeros(nnz, dtype=complex)
-        D = np.zeros((nnz, len(self.precomputed_As)), dtype=complex)
+        a0 = np.zeros(nnz, dtype=dtype)
+        D = np.zeros((nnz, len(self.precomputed_As)), dtype=dtype)
         for j, m in enumerate(mats):
             slots = sp.csc_array(slot_carrier.multiply(pattern(m)))
             slots.sort_indices()
@@ -589,8 +596,8 @@ class _SharedProjQCQP(ABC):
 
         Shift-invert at sigma=0 works by applying A^{-1}, and left to itself
         ``eigsh`` builds a factorization of A for that purpose and throws it away
-        on return. 
-        
+        on return.
+
         Subclasses that can apply A^{-1} more cheaply say so through
         :meth:`_shift_invert_OPinv`. A(lags) is also factorized through
         ``_get_factorization`` rather than merely assembled, so a factor already in
@@ -683,7 +690,11 @@ class _SharedProjQCQP(ABC):
         ComplexArray
             Block of shape (len(v), n_proj_constr + n_gen_constr).
         """
-        out = np.empty((len(v), self.get_number_constraints()), dtype=complex)
+        # Sized from the loop's own source: precomputed_As always has one entry per
+        # constraint, but sizing from get_number_constraints() instead would leave
+        # trailing columns uninitialized in the case
+        # of a subclass that over-rides that.
+        out = np.empty((len(v), len(self.precomputed_As)), dtype=complex)
         for k, Ak in enumerate(self.precomputed_As):
             out[:, k] = Ak @ v
         return out

--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -220,6 +220,15 @@ class _SharedProjQCQP(ABC):
         # (A1, A2, s1, Pstruct), which are fixed after construction.
         self._hs_kernel_cache: Optional[Tuple[Any, Any, Any]] = None
 
+        # Fixed-pattern representation of A(lags), built lazily by _build_assembly_map.
+        # None means sum the A_k elementwise, _built distinguishes that from not
+        # having built it yet
+        self._assembly_map: Optional[
+            Tuple[Any, Any, Tuple[int, int], ComplexArray, ComplexArray]
+        ] = None
+        self._assembly_map_built = False
+        self._assembly_map_max_bytes = 512 * 1024**2
+
         if self.use_precomp:
             self.compute_precomputed_values()
 
@@ -290,8 +299,82 @@ class _SharedProjQCQP(ABC):
         )
 
     def _get_total_A_precomp(self, lags: FloatNDArray) -> sp.csc_array | ComplexArray:
-        """Return total A using precomputed_As (fast path for few constraints)."""
-        return self.A0 + sum(lags[i] * self.precomputed_As[i] for i in range(len(lags)))
+        """Return total A using precomputed_As.
+
+        Assembles on the fixed pattern when one is available (see
+        ``_build_assembly_map``), otherwise sums the A_k elmentwise.
+        """
+        if not self._assembly_map_built:
+            self._assembly_map = self._build_assembly_map()
+            self._assembly_map_built = True
+        if self._assembly_map is None:
+            return self.A0 + sum(
+                lags[i] * self.precomputed_As[i] for i in range(len(lags))
+            )
+        indptr, indices, shape, a0, D = self._assembly_map
+        data = a0 + D[:, : len(lags)] @ lags
+        return sp.csc_array((data, indices, indptr), shape=shape)
+
+    def _build_assembly_map(
+        self,
+    ) -> Optional[Tuple[Any, Any, Tuple[int, int], ComplexArray, ComplexArray]]:
+        """Return a fixed-pattern representation of A(lags), or None if unavailable.
+
+        Every A_k is supported inside one lags-independent pattern so A(lags) needs no 
+        index merging at all. Holding each A_k's entries in their slots in that pattern 
+        as the columns of a dense ``(nnz, n_constr)`` block D,
+
+            A(lags).data = a0 + D @ lags
+
+        which is one operation over contiguous memory in place of ``n_constr`` sparse
+        additions that each merge two index structures and allocate. 
+
+        Returns None (leaving the elmentwise sum in use) when the formulation is
+        dense, where the A_k are full n^2 matrices with no pattern to share, or when
+        D would exceed ``_assembly_map_max_bytes``.
+
+        Returns
+        -------
+        tuple | None
+            ``(indptr, indices, shape, a0, D)``, or None.
+        """
+        if not sp.issparse(self.A0) or not self.precomputed_As:
+            return None
+
+        mats = [sp.csc_array(self.A0)] + [sp.csc_array(a) for a in self.precomputed_As]
+        for m in mats:
+            m.sort_indices()
+
+        def pattern(m: sp.csc_array) -> sp.csc_array:
+            ones = m.copy()
+            ones.data = np.ones(m.nnz)
+            return ones
+
+        union = pattern(mats[0])
+        for m in mats[1:]:
+            union = union + pattern(m)
+        union = sp.csc_array(union)
+        union.sort_indices()
+
+        nnz = union.nnz
+        if nnz * len(self.precomputed_As) * 16 > self._assembly_map_max_bytes:
+            return None
+
+        slot_carrier = union.copy()
+        slot_carrier.data = np.arange(1, nnz + 1, dtype=float)
+
+        a0 = np.zeros(nnz, dtype=complex)
+        D = np.zeros((nnz, len(self.precomputed_As)), dtype=complex)
+        for j, m in enumerate(mats):
+            slots = sp.csc_array(slot_carrier.multiply(pattern(m)))
+            slots.sort_indices()
+            pos = slots.data.astype(np.int64) - 1
+            if j == 0:
+                a0[pos] = m.data
+            else:
+                D[pos, j - 1] = m.data
+
+        return union.indptr, union.indices, union.shape, a0, D
 
     def _get_total_A_noprecomp(self, lags: FloatNDArray) -> sp.csc_array | ComplexArray:
         """Return total A without precomputation (better for many constraints)."""
@@ -346,12 +429,16 @@ class _SharedProjQCQP(ABC):
         return np.ascontiguousarray(lags, dtype=np.float64).tobytes()
 
     def _invalidate_factor_cache(self) -> None:
-        """Drop all cached factorizations.
+        """Drop all cached factorizations and the fixed-pattern assembly map.
 
         Must be called whenever A(lags) changes for a fixed lags, i.e. whenever
-        A0, precomputed_As or the constraint set are modified.
+        A0, precomputed_As or the constraint set are modified. The assembly map is
+        dropped here too: it holds a copy of every A_k's data, so it goes stale
+        under the same edits.
         """
         self._factor_cache.clear()
+        self._assembly_map = None
+        self._assembly_map_built = False
 
     def _store_factor(self, key: bytes, A: Any, factor: Any) -> None:
         """Record (A, factor) for ``key`` and mark it the active factorization.

--- a/dolphindes/cvxopt/_base_qcqp.py
+++ b/dolphindes/cvxopt/_base_qcqp.py
@@ -15,6 +15,18 @@ from .optimization import BFGS, Alt_Newton_GD, OptimizationHyperparameters, _Opt
 if TYPE_CHECKING:
     from .gcd import GCDHyperparameters, OrthoMetric
 
+# Auxiliary components returned by get_dual
+DualAux = namedtuple(
+    "DualAux",
+    [
+        "dualval_real",
+        "dualgrad_real",
+        "dualval_penalty",
+        "grad_penalty",
+        "hess_penalty",
+    ],
+)
+
 
 class _SharedProjQCQP(ABC):
     """Represents a quadratically constrained quadratic program (QCQP).
@@ -570,6 +582,25 @@ class _SharedProjQCQP(ABC):
 
         return x_star, xAx
 
+    def _allA_at_v(self, v: ComplexArray) -> ComplexArray:
+        """
+        Apply every constraint operator to v: return the block with columns A_k v.
+
+        Parameters
+        ----------
+        v : ComplexArray
+            Vector to apply the constraint operators to.
+
+        Returns
+        -------
+        ComplexArray
+            Block of shape (len(v), n_proj_constr + n_gen_constr).
+        """
+        out = np.empty((len(v), self.get_number_constraints()), dtype=complex)
+        for k, Ak in enumerate(self.precomputed_As):
+            out[:, k] = Ak @ v
+        return out
+
     def get_dual(
         self,
         lags: FloatNDArray,
@@ -621,26 +652,15 @@ class _SharedProjQCQP(ABC):
         dualval += self.c0 + self._get_total_C(lags)
 
         if get_hess:
-            try:
-                # useful intermediate computations
-                # (Fx)_k = -A_k @ x_star
-                # where A_k is quadratic form of constraints
+            # (Fx)_k = -A_k @ x_star, where A_k is the quadratic form of constraint k
+            Fx = -self._allA_at_v(xstar)
 
-                Fx = np.zeros((len(xstar), len(self.precomputed_As)), dtype=complex)
-                for k, Ak in enumerate(self.precomputed_As):
-                    Fx[:, k] = -Ak @ xstar
+            # get_hess implies get_grad also
+            grad = np.real(xstar.conj() @ (Fx + 2 * self.Fs))
+            grad[self.n_proj_constr :] += self.c_2j
 
-                # get_hess implies get_grad also
-                grad = np.real(xstar.conj() @ (Fx + 2 * self.Fs))
-                grad[self.n_proj_constr :] += self.c_2j
-
-                Ftot = Fx + self.Fs
-                hess = 2 * np.real(Ftot.conj().T @ self._Acho_solve(Ftot))
-            except AttributeError:
-                # this assumes that in the future we may consider making
-                # precomputed_As optional can also compute the Hessian without
-                # precomputed_As, leave for future implementation if useful
-                raise AttributeError("precomputed_As needed for computing Hessian")
+            Ftot = Fx + self.Fs
+            hess = 2 * np.real(Ftot.conj().T @ self._Acho_solve(Ftot))
 
         elif get_grad:
             # Generic projector gradient (works for diagonal and general P)
@@ -709,11 +729,8 @@ class _SharedProjQCQP(ABC):
                 # are quadratic in p_j, so the sum over j cannot be collapsed by
                 # summing Fv first: sum_j x_j^† M x_j is not
                 # (sum_j x_j)^† M (sum_j x_j).
-                Fv = np.zeros((penalty_matrix.shape[0], len(grad)), dtype=complex)
                 for j in range(penalty_matrix.shape[1]):
-                    for k, Ak in enumerate(self.precomputed_As):
-                        Fv[:, k] = Ak @ A_inv_penalty[:, j]
-
+                    Fv = self._allA_at_v(A_inv_penalty[:, j])
                     grad_penalty += np.real(-A_inv_penalty[:, j].conj().T @ Fv)
                     hess_penalty += 2 * np.real(Fv.conj().T @ self._Acho_solve(Fv))
 
@@ -747,16 +764,6 @@ class _SharedProjQCQP(ABC):
                 else:
                     grad_penalty = proj_grad_penalty
 
-        DualAux = namedtuple(
-            "DualAux",
-            [
-                "dualval_real",
-                "dualgrad_real",
-                "dualval_penalty",
-                "grad_penalty",
-                "hess_penalty",
-            ],
-        )
         dual_aux = DualAux(
             dualval_real=dualval,
             dualgrad_real=grad,

--- a/examples/limits/LDOS_gcd.ipynb
+++ b/examples/limits/LDOS_gcd.ipynb
@@ -49,7 +49,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7a82720f3e20>"
+       "<matplotlib.image.AxesImage at 0x794718762350>"
       ]
      },
      "execution_count": null,
@@ -204,51 +204,51 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found feasible point for dual problem: [4.65425982e-07 1.00000000e-01] with dualvalue 748.2390964693494\n"
+      "Found feasible point for dual problem: [6.5682869e-07 1.0000000e-01] with dualvalue 721.278437427063\n",
+      "Splitting projectors: 2 → Precomputed 4 A matrices and Fs vectors.\n",
+      "previous dual: 1.99060087341935, new dual: 1.9906008734193679 (should match)\n",
+      "4\n",
+      "at step 1, number of constraints is 4, bound is 1.9551398986633108\n",
+      "Splitting projectors: 4 → Precomputed 8 A matrices and Fs vectors.\n",
+      "previous dual: 1.9551398986633108, new dual: 1.955139898663312 (should match)\n",
+      "8\n",
+      "at step 2, number of constraints is 8, bound is 1.8715794692205434\n",
+      "Splitting projectors: 8 → Precomputed 16 A matrices and Fs vectors.\n",
+      "previous dual: 1.8715794692205434, new dual: 1.8715794692206367 (should match)\n",
+      "16\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Splitting projectors: 2 → Precomputed 4 A matrices and Fs vectors.\n",
-      "previous dual: 1.990600873420365, new dual: 1.9906008734203047 (should match)\n",
-      "4\n",
-      "at step 1, number of constraints is 4, bound is 1.9551398986634623\n",
-      "Splitting projectors: 4 → Precomputed 8 A matrices and Fs vectors.\n",
-      "previous dual: 1.9551398986634623, new dual: 1.955139898663501 (should match)\n",
-      "8\n",
-      "at step 2, number of constraints is 8, bound is 1.871579469219635\n",
-      "Splitting projectors: 8 → Precomputed 16 A matrices and Fs vectors.\n",
-      "previous dual: 1.871579469219635, new dual: 1.8715794692196763 (should match)\n",
-      "16\n",
-      "at step 3, number of constraints is 16, bound is 1.860619459318624\n",
+      "at step 3, number of constraints is 16, bound is 1.860619481910062\n",
       "Splitting projectors: 16 → Precomputed 32 A matrices and Fs vectors.\n",
-      "previous dual: 1.8564669137992438, new dual: 1.8564669137993586 (should match)\n",
+      "previous dual: 1.8564669246131904, new dual: 1.856466924613213 (should match)\n",
       "32\n",
-      "at step 4, number of constraints is 32, bound is 1.8346626205147334\n",
+      "at step 4, number of constraints is 32, bound is 1.8346626256108467\n",
       "Splitting projectors: 32 → Precomputed 64 A matrices and Fs vectors.\n",
-      "previous dual: 1.8306398801315271, new dual: 1.830639880131615 (should match)\n",
+      "previous dual: 1.8306398828148733, new dual: 1.8306398828145605 (should match)\n",
       "64\n",
-      "at step 5, number of constraints is 64, bound is 1.756457653375236\n",
+      "at step 5, number of constraints is 64, bound is 1.7564576543130026\n",
       "Splitting projectors: 64 → Precomputed 128 A matrices and Fs vectors.\n",
-      "previous dual: 1.7531410785394241, new dual: 1.7531410785396029 (should match)\n",
+      "previous dual: 1.7531410791560087, new dual: 1.7531410791559996 (should match)\n",
       "128\n",
-      "at step 6, number of constraints is 128, bound is 1.6069623094246173\n",
+      "at step 6, number of constraints is 128, bound is 1.6069623108182585\n",
       "Splitting projectors: 128 → Precomputed 256 A matrices and Fs vectors.\n",
-      "previous dual: 1.604327197236071, new dual: 1.6043271972360305 (should match)\n",
+      "previous dual: 1.6043271980093365, new dual: 1.604327198009386 (should match)\n",
       "256\n",
-      "at step 7, number of constraints is 256, bound is 1.5669042694075455\n",
+      "at step 7, number of constraints is 256, bound is 1.5669042692692183\n",
       "Splitting projectors: 256 → Precomputed 512 A matrices and Fs vectors.\n",
-      "previous dual: 1.563947204176631, new dual: 1.563947204176512 (should match)\n",
+      "previous dual: 1.5639472040812268, new dual: 1.5639472040812454 (should match)\n",
       "512\n",
-      "at step 8, number of constraints is 512, bound is 1.5507856001276572\n",
+      "at step 8, number of constraints is 512, bound is 1.5507856257789847\n",
       "Splitting projectors: 512 → Precomputed 800 A matrices and Fs vectors.\n",
-      "previous dual: 1.545950301183033, new dual: 1.5459503011832398 (should match)\n",
+      "previous dual: 1.5459503181800904, new dual: 1.5459503181802492 (should match)\n",
       "800\n",
-      "at step 9, number of constraints is 800, bound is 1.5328749241957618\n",
+      "at step 9, number of constraints is 800, bound is 1.5328761429496358\n",
       "Reached maximum projectors or pixel-level constraints.\n",
-      "Newton iterative splitting took 5.147186517715454s to reach pixel level.\n"
+      "Newton iterative splitting took 5.244039535522461s to reach pixel level.\n"
      ]
     }
    ],
@@ -277,35 +277,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found feasible point for dual problem: [2.82027538e-07 1.00000000e-01] with dualvalue 776.6719833769738\n",
+      "Found feasible point for dual problem: [3.51820889e-07 1.00000000e-01] with dualvalue 765.5257191639631\n",
       "Precomputed 2 A matrices and Fs vectors.\n",
-      "At GCD iteration #1, best dual bound found is             1.9906008734215233.\n",
-      "At GCD iteration #2, best dual bound found is             1.7469383568981631.\n"
+      "At GCD iteration #1, best dual bound found is             1.9906008734230372.\n",
+      "At GCD iteration #2, best dual bound found is             1.7469382908855637.\n",
+      "At GCD iteration #3, best dual bound found is             1.6904014564613132.\n",
+      "At GCD iteration #4, best dual bound found is             1.6691171650627556.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "At GCD iteration #3, best dual bound found is             1.6904014773780318.\n",
-      "At GCD iteration #4, best dual bound found is             1.6691172072946325.\n",
-      "At GCD iteration #5, best dual bound found is             1.6611702337979601.\n",
-      "At GCD iteration #6, best dual bound found is             1.6452481014857425.\n",
-      "At GCD iteration #7, best dual bound found is             1.6361470507783198.\n",
-      "At GCD iteration #8, best dual bound found is             1.6302547172594009.\n",
-      "At GCD iteration #9, best dual bound found is             1.6182098448245215.\n",
-      "At GCD iteration #10, best dual bound found is             1.6086168238958998.\n",
-      "At GCD iteration #11, best dual bound found is             1.6037185691894342.\n",
-      "At GCD iteration #12, best dual bound found is             1.5899712804056643.\n",
-      "At GCD iteration #13, best dual bound found is             1.585341703766157.\n",
-      "At GCD iteration #14, best dual bound found is             1.5841761050141674.\n",
-      "At GCD iteration #15, best dual bound found is             1.580825440029089.\n",
-      "At GCD iteration #16, best dual bound found is             1.5805087349789186.\n",
-      "At GCD iteration #17, best dual bound found is             1.5782599200197858.\n",
-      "At GCD iteration #18, best dual bound found is             1.5771790251293898.\n",
-      "At GCD iteration #19, best dual bound found is             1.5771664541774173.\n",
-      "At GCD iteration #20, best dual bound found is             1.576797846137292.\n",
-      "gcd took time 0.9888772964477539 to reach 1.028653950330993 of pixel dual.\n"
+      "At GCD iteration #5, best dual bound found is             1.6611702010892855.\n",
+      "At GCD iteration #6, best dual bound found is             1.64524801564678.\n",
+      "At GCD iteration #7, best dual bound found is             1.6361469764297305.\n",
+      "At GCD iteration #8, best dual bound found is             1.6302546403221558.\n",
+      "At GCD iteration #9, best dual bound found is             1.6182098205765643.\n",
+      "At GCD iteration #10, best dual bound found is             1.6086164956711209.\n",
+      "At GCD iteration #11, best dual bound found is             1.6037183623474391.\n",
+      "At GCD iteration #12, best dual bound found is             1.5899711727318928.\n",
+      "At GCD iteration #13, best dual bound found is             1.585341473656067.\n",
+      "At GCD iteration #14, best dual bound found is             1.5841756636720248.\n",
+      "At GCD iteration #15, best dual bound found is             1.5808245736375326.\n",
+      "At GCD iteration #16, best dual bound found is             1.580508235184357.\n",
+      "At GCD iteration #17, best dual bound found is             1.5782595987657375.\n",
+      "At GCD iteration #18, best dual bound found is             1.5771793422464173.\n",
+      "At GCD iteration #19, best dual bound found is             1.5771761378602747.\n",
+      "At GCD iteration #20, best dual bound found is             1.5767905126247925.\n",
+      "gcd took time 1.0543477535247803 to reach 1.0286483483203375 of pixel dual.\n"
      ]
     }
    ],
@@ -353,24 +353,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Precomputed 10 A matrices and Fs vectors.\n",
-      "At GCD iteration #1, best dual bound found is             1.5641909789757422.\n",
-      "At GCD iteration #2, best dual bound found is             1.565033541870952.\n",
-      "At GCD iteration #3, best dual bound found is             1.5647727832260945.\n",
-      "At GCD iteration #4, best dual bound found is             1.5651176255290398.\n",
-      "At GCD iteration #5, best dual bound found is             1.5618023114391335.\n",
-      "At GCD iteration #6, best dual bound found is             1.5637845111988984.\n",
-      "At GCD iteration #7, best dual bound found is             1.5636990360575393.\n",
-      "At GCD iteration #8, best dual bound found is             1.5629718507375585.\n",
-      "At GCD iteration #9, best dual bound found is             1.5629748492047408.\n",
-      "At GCD iteration #10, best dual bound found is             1.56269807020406.\n",
-      "gcd took time 0.5937545299530029 to reach 1.019455694354153 of pixel dual.\n"
+      "Found feasible point for dual problem: [7.16147441e-07 1.00000000e-01] with dualvalue 713.4224867289229\n",
+      "Precomputed 2 A matrices and Fs vectors.\n",
+      "At GCD iteration #1, best dual bound found is             1.9906008736437484.\n",
+      "At GCD iteration #2, best dual bound found is             1.746936749682098.\n",
+      "At GCD iteration #3, best dual bound found is             1.6903994462982173.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At GCD iteration #4, best dual bound found is             1.669115490534181.\n",
+      "At GCD iteration #5, best dual bound found is             1.661220228967378.\n",
+      "At GCD iteration #6, best dual bound found is             1.6450083359790981.\n",
+      "At GCD iteration #7, best dual bound found is             1.6338711606033103.\n",
+      "At GCD iteration #8, best dual bound found is             1.6269153457248646.\n",
+      "At GCD iteration #9, best dual bound found is             1.616980354941644.\n",
+      "At GCD iteration #10, best dual bound found is             1.610657774739888.\n",
+      "At GCD iteration #11, best dual bound found is             1.6030880552058469.\n",
+      "At GCD iteration #12, best dual bound found is             1.5913525801024346.\n",
+      "At GCD iteration #13, best dual bound found is             1.5862883811288169.\n",
+      "At GCD iteration #14, best dual bound found is             1.5792535191456205.\n",
+      "At GCD iteration #15, best dual bound found is             1.5763680422847188.\n",
+      "At GCD iteration #16, best dual bound found is             1.5767912735427336.\n",
+      "At GCD iteration #17, best dual bound found is             1.5683914374143784.\n",
+      "At GCD iteration #18, best dual bound found is             1.5649661027709565.\n",
+      "At GCD iteration #19, best dual bound found is             1.5633312800374584.\n",
+      "At GCD iteration #20, best dual bound found is             1.563883106559043.\n",
+      "gcd took time 1.2934541702270508 to reach 1.0202279641130967 of pixel dual.\n"
      ]
     }
    ],
    "source": [
     "# We may also use the Hilbert-Schmidt metric, which is slower per iteration but may lead to faster or better convergence\n",
-    "gcd_QCQP = copy.deepcopy(ldos_problem.QCQP)\n",
     "t = time.time()\n",
     "gcd_params = gcd.GCDHyperparameters(\n",
     "    max_proj_cstrt_num=max_cstrt_num,\n",

--- a/examples/limits/LDOS_gcd.ipynb
+++ b/examples/limits/LDOS_gcd.ipynb
@@ -21,16 +21,7 @@
    "execution_count": null,
    "id": "1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload"
    ]
@@ -58,7 +49,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x79e75a97e9b0>"
+       "<matplotlib.image.AxesImage at 0x7a82720f3e20>"
       ]
      },
      "execution_count": null,
@@ -213,7 +204,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found feasible point for dual problem: [5.41788396e-08 1.00000000e-01] with dualvalue 816.2080132586462\n"
+      "Found feasible point for dual problem: [4.65425982e-07 1.00000000e-01] with dualvalue 748.2390964693494\n"
      ]
     },
     {
@@ -221,43 +212,43 @@
      "output_type": "stream",
      "text": [
       "Splitting projectors: 2 → Precomputed 4 A matrices and Fs vectors.\n",
-      "previous dual: 1.990600873418748, new dual: 1.9906008734187208 (should match)\n",
+      "previous dual: 1.990600873420365, new dual: 1.9906008734203047 (should match)\n",
       "4\n",
-      "at step 1, number of constraints is 4, bound is 1.9551398986638036\n",
+      "at step 1, number of constraints is 4, bound is 1.9551398986634623\n",
       "Splitting projectors: 4 → Precomputed 8 A matrices and Fs vectors.\n",
-      "previous dual: 1.9551398986638036, new dual: 1.9551398986637052 (should match)\n",
+      "previous dual: 1.9551398986634623, new dual: 1.955139898663501 (should match)\n",
       "8\n",
-      "at step 2, number of constraints is 8, bound is 1.8715794692206325\n",
+      "at step 2, number of constraints is 8, bound is 1.871579469219635\n",
       "Splitting projectors: 8 → Precomputed 16 A matrices and Fs vectors.\n",
-      "previous dual: 1.8715794692206325, new dual: 1.8715794692206873 (should match)\n",
+      "previous dual: 1.871579469219635, new dual: 1.8715794692196763 (should match)\n",
       "16\n",
-      "at step 3, number of constraints is 16, bound is 1.86061948342903\n",
+      "at step 3, number of constraints is 16, bound is 1.860619459318624\n",
       "Splitting projectors: 16 → Precomputed 32 A matrices and Fs vectors.\n",
-      "previous dual: 1.8564669252943178, new dual: 1.856466925294244 (should match)\n",
+      "previous dual: 1.8564669137992438, new dual: 1.8564669137993586 (should match)\n",
       "32\n",
-      "at step 4, number of constraints is 32, bound is 1.8346626259272552\n",
+      "at step 4, number of constraints is 32, bound is 1.8346626205147334\n",
       "Splitting projectors: 32 → Precomputed 64 A matrices and Fs vectors.\n",
-      "previous dual: 1.830639882980767, new dual: 1.8306398829804047 (should match)\n",
+      "previous dual: 1.8306398801315271, new dual: 1.830639880131615 (should match)\n",
       "64\n",
-      "at step 5, number of constraints is 64, bound is 1.7564576543713888\n",
+      "at step 5, number of constraints is 64, bound is 1.756457653375236\n",
       "Splitting projectors: 64 → Precomputed 128 A matrices and Fs vectors.\n",
-      "previous dual: 1.753141079194479, new dual: 1.7531410791945412 (should match)\n",
+      "previous dual: 1.7531410785394241, new dual: 1.7531410785396029 (should match)\n",
       "128\n",
-      "at step 6, number of constraints is 128, bound is 1.6056830226992571\n",
+      "at step 6, number of constraints is 128, bound is 1.6069623094246173\n",
       "Splitting projectors: 128 → Precomputed 256 A matrices and Fs vectors.\n",
-      "previous dual: 1.6047359180016323, new dual: 1.6047359180016803 (should match)\n",
+      "previous dual: 1.604327197236071, new dual: 1.6043271972360305 (should match)\n",
       "256\n",
-      "at step 7, number of constraints is 256, bound is 1.5765102131704438\n",
+      "at step 7, number of constraints is 256, bound is 1.5669042694075455\n",
       "Splitting projectors: 256 → Precomputed 512 A matrices and Fs vectors.\n",
-      "previous dual: 1.572773343069001, new dual: 1.5727733430692474 (should match)\n",
+      "previous dual: 1.563947204176631, new dual: 1.563947204176512 (should match)\n",
       "512\n",
-      "at step 8, number of constraints is 512, bound is 1.5557944042003922\n",
+      "at step 8, number of constraints is 512, bound is 1.5507856001276572\n",
       "Splitting projectors: 512 → Precomputed 800 A matrices and Fs vectors.\n",
-      "previous dual: 1.5547870055683592, new dual: 1.5547870055685937 (should match)\n",
+      "previous dual: 1.545950301183033, new dual: 1.5459503011832398 (should match)\n",
       "800\n",
-      "at step 9, number of constraints is 800, bound is 1.5454809807765972\n",
+      "at step 9, number of constraints is 800, bound is 1.5328749241957618\n",
       "Reached maximum projectors or pixel-level constraints.\n",
-      "Newton iterative splitting took 43.612792015075684s to reach pixel level.\n"
+      "Newton iterative splitting took 5.147186517715454s to reach pixel level.\n"
      ]
     }
    ],
@@ -286,35 +277,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found feasible point for dual problem: [2.055518e-07 1.000000e-01] with dualvalue 789.381050098289\n",
-      "Precomputed 2 A matrices and Fs vectors.\n"
+      "Found feasible point for dual problem: [2.82027538e-07 1.00000000e-01] with dualvalue 776.6719833769738\n",
+      "Precomputed 2 A matrices and Fs vectors.\n",
+      "At GCD iteration #1, best dual bound found is             1.9906008734215233.\n",
+      "At GCD iteration #2, best dual bound found is             1.7469383568981631.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "At GCD iteration #1, best dual bound found is             1.9906008734198435.\n",
-      "At GCD iteration #2, best dual bound found is             1.7469384268205286.\n",
-      "At GCD iteration #3, best dual bound found is             1.6904015371494634.\n",
-      "At GCD iteration #4, best dual bound found is             1.669117289771638.\n",
-      "At GCD iteration #5, best dual bound found is             1.6611703027651563.\n",
-      "At GCD iteration #6, best dual bound found is             1.6452481749189358.\n",
-      "At GCD iteration #7, best dual bound found is             1.6361471371787073.\n",
-      "At GCD iteration #8, best dual bound found is             1.6302547947455026.\n",
-      "At GCD iteration #9, best dual bound found is             1.6182099497837665.\n",
-      "At GCD iteration #10, best dual bound found is             1.6086168530098797.\n",
-      "At GCD iteration #11, best dual bound found is             1.603718146915681.\n",
-      "At GCD iteration #12, best dual bound found is             1.589971296147006.\n",
-      "At GCD iteration #13, best dual bound found is             1.5853419862753348.\n",
-      "At GCD iteration #14, best dual bound found is             1.584176382488307.\n",
-      "At GCD iteration #15, best dual bound found is             1.5808257653080457.\n",
-      "At GCD iteration #16, best dual bound found is             1.5805080948875025.\n",
-      "At GCD iteration #17, best dual bound found is             1.5782609239532965.\n",
-      "At GCD iteration #18, best dual bound found is             1.5771810785746125.\n",
-      "At GCD iteration #19, best dual bound found is             1.576804060346324.\n",
-      "At GCD iteration #20, best dual bound found is             1.5767441307951382.\n",
-      "gcd took time 3.398860216140747 to reach 1.0202287510538184 of pixel dual.\n"
+      "At GCD iteration #3, best dual bound found is             1.6904014773780318.\n",
+      "At GCD iteration #4, best dual bound found is             1.6691172072946325.\n",
+      "At GCD iteration #5, best dual bound found is             1.6611702337979601.\n",
+      "At GCD iteration #6, best dual bound found is             1.6452481014857425.\n",
+      "At GCD iteration #7, best dual bound found is             1.6361470507783198.\n",
+      "At GCD iteration #8, best dual bound found is             1.6302547172594009.\n",
+      "At GCD iteration #9, best dual bound found is             1.6182098448245215.\n",
+      "At GCD iteration #10, best dual bound found is             1.6086168238958998.\n",
+      "At GCD iteration #11, best dual bound found is             1.6037185691894342.\n",
+      "At GCD iteration #12, best dual bound found is             1.5899712804056643.\n",
+      "At GCD iteration #13, best dual bound found is             1.585341703766157.\n",
+      "At GCD iteration #14, best dual bound found is             1.5841761050141674.\n",
+      "At GCD iteration #15, best dual bound found is             1.580825440029089.\n",
+      "At GCD iteration #16, best dual bound found is             1.5805087349789186.\n",
+      "At GCD iteration #17, best dual bound found is             1.5782599200197858.\n",
+      "At GCD iteration #18, best dual bound found is             1.5771790251293898.\n",
+      "At GCD iteration #19, best dual bound found is             1.5771664541774173.\n",
+      "At GCD iteration #20, best dual bound found is             1.576797846137292.\n",
+      "gcd took time 0.9888772964477539 to reach 1.028653950330993 of pixel dual.\n"
      ]
     }
    ],
@@ -362,29 +353,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found feasible point for dual problem: [6.21838174e-07 1.00000000e-01] with dualvalue 726.018736123337\n",
-      "Precomputed 2 A matrices and Fs vectors.\n",
-      "At GCD iteration #1, best dual bound found is             1.9906008743566286.\n",
-      "At GCD iteration #2, best dual bound found is             1.7469424006141143.\n",
-      "At GCD iteration #3, best dual bound found is             1.6904022844291133.\n",
-      "At GCD iteration #4, best dual bound found is             1.669118646168242.\n",
-      "At GCD iteration #5, best dual bound found is             1.6612231598651965.\n",
-      "At GCD iteration #6, best dual bound found is             1.6450098782106113.\n",
-      "At GCD iteration #7, best dual bound found is             1.633875885312799.\n",
-      "At GCD iteration #8, best dual bound found is             1.6269193755699332.\n",
-      "At GCD iteration #9, best dual bound found is             1.6169850384810138.\n",
-      "At GCD iteration #10, best dual bound found is             1.610662001684383.\n",
-      "At GCD iteration #11, best dual bound found is             1.603090291203674.\n",
-      "At GCD iteration #12, best dual bound found is             1.5913546683547983.\n",
-      "At GCD iteration #13, best dual bound found is             1.5862866331491277.\n",
-      "At GCD iteration #14, best dual bound found is             1.5792711288131023.\n",
-      "At GCD iteration #15, best dual bound found is             1.5773331231907368.\n",
-      "At GCD iteration #16, best dual bound found is             1.5773213500490737.\n",
-      "At GCD iteration #17, best dual bound found is             1.5693330528214062.\n",
-      "At GCD iteration #18, best dual bound found is             1.568301511814236.\n",
-      "At GCD iteration #19, best dual bound found is             1.564442968095412.\n",
-      "At GCD iteration #20, best dual bound found is             1.5655280951436892.\n",
-      "gcd took time 3.877166271209717 to reach 1.0129714403583396 of pixel dual.\n"
+      "Precomputed 10 A matrices and Fs vectors.\n",
+      "At GCD iteration #1, best dual bound found is             1.5641909789757422.\n",
+      "At GCD iteration #2, best dual bound found is             1.565033541870952.\n",
+      "At GCD iteration #3, best dual bound found is             1.5647727832260945.\n",
+      "At GCD iteration #4, best dual bound found is             1.5651176255290398.\n",
+      "At GCD iteration #5, best dual bound found is             1.5618023114391335.\n",
+      "At GCD iteration #6, best dual bound found is             1.5637845111988984.\n",
+      "At GCD iteration #7, best dual bound found is             1.5636990360575393.\n",
+      "At GCD iteration #8, best dual bound found is             1.5629718507375585.\n",
+      "At GCD iteration #9, best dual bound found is             1.5629748492047408.\n",
+      "At GCD iteration #10, best dual bound found is             1.56269807020406.\n",
+      "gcd took time 0.5937545299530029 to reach 1.019455694354153 of pixel dual.\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ extend-exclude = ["*.ipynb", "build", "dist"]
 
 [tool.ruff.lint]
 # Enable general linting + docstring checks
-select = ["E", "F", "I", "D"]
+select = ["E", "W", "F", "I", "D"]
 # jaxtyping shape annotations such as Complex[Array, " n"] contain string shape
 # specs that pyflakes parses as forward references; F722 would flag them as
 # syntax errors. The shape names live inside the string, so F821 is unaffected.

--- a/tests/test_qcqp.py
+++ b/tests/test_qcqp.py
@@ -885,7 +885,108 @@ def test_hs_kernel_cache_reused():
     k1 = gcd._hs_kernels(qcqp)
     k2 = gcd._hs_kernels(qcqp)
     for a, b in zip(k1, k2):
-        assert a is b  # same cached array objects, not recomputed
+        assert a is b
+
+
+def _elementwise_total_A(qcqp, lags):
+    """A(lags) summed one constraint at a time, i.e. without the assembly map."""
+    return qcqp.A0 + sum(
+        lags[i] * qcqp.precomputed_As[i] for i in range(len(lags))
+    )
+
+
+def _assert_total_A_matches_elementwise(qcqp, lags, atol=1e-12):
+    got = sp.csc_array(qcqp._get_total_A(lags))
+    want = sp.csc_array(_elementwise_total_A(qcqp, lags))
+    assert abs(got - want).max() <= atol * abs(want).max()
+
+
+def _sparse_qcqp_for_assembly(diagonal, n_gen, n=12, k=4, seed=5):
+    """A sparse QCQP with diagonal or non-diagonal projectors and optional general
+    constraints, for exercising the fixed-pattern assembly of A(lags)."""
+    rng = np.random.default_rng(seed)
+
+    def rc(shape):
+        return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+    if diagonal:
+        # unequal, partly overlapping supports, as refine_projectors produces
+        diags = rc((n, k))
+        diags[rng.random((n, k)) < 0.4] = 0.0
+        Projlist = [sp.diags_array(diags[:, j], format="csc") for j in range(k)]
+    else:
+        Projlist = [sp.csc_array(np.outer(v, v.conj())) for v in (rc(n) for _ in range(k))]
+    Pstruct = Projlist[0] != 0
+    for P in Projlist[1:]:
+        Pstruct = Pstruct.maximum(P != 0)
+
+    A0 = sp.csc_array(sp.eye_array(n, format="csc") * 3.0)
+    return SparseSharedProjQCQP(
+        A0, rc(n), 0.0, sp.csc_array(rc((n, n))), sp.csc_array(rc((n, n))), rc(n),
+        Projlist, sp.csc_array(Pstruct),
+        B_j=[sp.csc_array(rc((n, n))) for _ in range(n_gen)] or None,
+        s_2j=[rc(n) for _ in range(n_gen)] or None,
+        c_2j=rng.standard_normal(n_gen) if n_gen else None,
+        verbose=0,
+    )
+
+
+@pytest.mark.parametrize("diagonal", [True, False])
+@pytest.mark.parametrize("n_gen", [0, 2])
+def test_assembly_map_matches_elementwise_sum(diagonal, n_gen):
+    """A(lags) assembled on the fixed pattern equals the elementwise sum, at more than
+    one lags (the second reuses the cached map)."""
+    qcqp = _sparse_qcqp_for_assembly(diagonal, n_gen)
+    n_constr = qcqp.get_number_constraints()
+    rng = np.random.default_rng(2)
+    _assert_total_A_matches_elementwise(qcqp, rng.standard_normal(n_constr))
+    assert qcqp._assembly_map is not None, "expected a fixed-pattern map here"
+    _assert_total_A_matches_elementwise(qcqp, rng.standard_normal(n_constr))
+
+
+def test_assembly_map_dropped_on_constraint_edits(sparse_qcqp_data):
+    """Every edit to the constraint set leaves A(lags) consistent: a surviving stale
+    map (it holds a copy of each A_k's data) would show up immediately."""
+    qcqp = sparse_qcqp_data["qcqp"]
+    qcqp.current_lags = qcqp.find_feasible_lags()
+    qcqp._get_total_A(np.abs(qcqp.current_lags))
+    assert qcqp._assembly_map is not None
+
+    qcqp._invalidate_factor_cache()
+    assert qcqp._assembly_map is None and not qcqp._assembly_map_built
+
+    rng = np.random.default_rng(0)
+    edits = [
+        lambda: qcqp.refine_projectors(),
+        lambda: qcqp.add_constraints(
+            [rng.standard_normal(qcqp.Proj.Pstruct.size) + 0j]
+        ),
+        lambda: qcqp.merge_lead_constraints(merged_num=2),
+    ]
+    for edit in edits:
+        qcqp._get_total_A(np.abs(qcqp.current_lags))  # build a map, then invalidate it
+        edit()
+        _assert_total_A_matches_elementwise(qcqp, np.abs(qcqp.current_lags))
+
+
+def test_assembly_map_falls_back_when_too_large(sparse_qcqp_data):
+    """Above the memory budget the map is declined and the elementwise sum is used."""
+    qcqp = sparse_qcqp_data["qcqp"]
+    lags = np.abs(qcqp.find_feasible_lags())
+    qcqp._assembly_map_max_bytes = 1
+    qcqp._invalidate_factor_cache()
+    _assert_total_A_matches_elementwise(qcqp, lags)
+    assert qcqp._assembly_map is None
+
+
+def test_assembly_map_declined_for_dense(dense_qcqp_data):
+    """The dense formulation has no shared pattern to exploit, so no map is built."""
+    qcqp = dense_qcqp_data["qcqp"]
+    lags = np.abs(qcqp.find_feasible_lags())
+    got = qcqp._get_total_A(lags)
+    want = _elementwise_total_A(qcqp, lags)
+    assert qcqp._assembly_map is None
+    assert np.allclose(got, want, atol=1e-12)
 
 
 def test_invalid_ortho_metric_raises():

--- a/tests/test_qcqp.py
+++ b/tests/test_qcqp.py
@@ -890,9 +890,7 @@ def test_hs_kernel_cache_reused():
 
 def _elementwise_total_A(qcqp, lags):
     """A(lags) summed one constraint at a time, i.e. without the assembly map."""
-    return qcqp.A0 + sum(
-        lags[i] * qcqp.precomputed_As[i] for i in range(len(lags))
-    )
+    return qcqp.A0 + sum(lags[i] * qcqp.precomputed_As[i] for i in range(len(lags)))
 
 
 def _assert_total_A_matches_elementwise(qcqp, lags, atol=1e-12):
@@ -915,18 +913,45 @@ def _sparse_qcqp_for_assembly(diagonal, n_gen, n=12, k=4, seed=5):
         diags[rng.random((n, k)) < 0.4] = 0.0
         Projlist = [sp.diags_array(diags[:, j], format="csc") for j in range(k)]
     else:
-        Projlist = [sp.csc_array(np.outer(v, v.conj())) for v in (rc(n) for _ in range(k))]
+        Projlist = [
+            sp.csc_array(np.outer(v, v.conj())) for v in (rc(n) for _ in range(k))
+        ]
     Pstruct = Projlist[0] != 0
     for P in Projlist[1:]:
         Pstruct = Pstruct.maximum(P != 0)
 
     A0 = sp.csc_array(sp.eye_array(n, format="csc") * 3.0)
     return SparseSharedProjQCQP(
-        A0, rc(n), 0.0, sp.csc_array(rc((n, n))), sp.csc_array(rc((n, n))), rc(n),
-        Projlist, sp.csc_array(Pstruct),
+        A0,
+        rc(n),
+        0.0,
+        sp.csc_array(rc((n, n))),
+        sp.csc_array(rc((n, n))),
+        rc(n),
+        Projlist,
+        sp.csc_array(Pstruct),
         B_j=[sp.csc_array(rc((n, n))) for _ in range(n_gen)] or None,
         s_2j=[rc(n) for _ in range(n_gen)] or None,
         c_2j=rng.standard_normal(n_gen) if n_gen else None,
+        verbose=0,
+    )
+
+
+def _real_sparse_qcqp_for_assembly(n=10, k=3, seed=8):
+    """A sparse QCQP whose quadratic parts are real. A0 keeps the dtype it is given on
+    the sparse path, so the assembly map must not promote such a problem to complex."""
+    rng = np.random.default_rng(seed)
+    Projlist = [sp.diags_array(rng.standard_normal(n), format="csc") for _ in range(k)]
+    Pstruct = sp.csc_array(sp.eye_array(n, format="csc"))
+    return SparseSharedProjQCQP(
+        sp.csc_array(sp.eye_array(n, format="csc") * 3.0),
+        rng.standard_normal(n),
+        0.0,
+        sp.csc_array(rng.standard_normal((n, n))),
+        sp.csc_array(rng.standard_normal((n, n))),
+        rng.standard_normal(n),
+        Projlist,
+        Pstruct,
         verbose=0,
     )
 
@@ -942,6 +967,50 @@ def test_assembly_map_matches_elementwise_sum(diagonal, n_gen):
     _assert_total_A_matches_elementwise(qcqp, rng.standard_normal(n_constr))
     assert qcqp._assembly_map is not None, "expected a fixed-pattern map here"
     _assert_total_A_matches_elementwise(qcqp, rng.standard_normal(n_constr))
+
+
+@pytest.mark.parametrize("diagonal", [True, False])
+@pytest.mark.parametrize("n_gen", [0, 2])
+def test_assembly_map_matches_elementwise_derivatives(diagonal, n_gen):
+    """The two assembly paths agree on what callers actually consume: the dual value,
+    its gradient and its Hessian, penalty terms included."""
+    qcqp = _sparse_qcqp_for_assembly(diagonal, n_gen)
+    rng = np.random.default_rng(3)
+    n = qcqp.A0.shape[0]
+    # A0 = 3I dominates at this scale, so a small point is interior
+    lags = 1e-3 * rng.standard_normal(qcqp.get_number_constraints())
+    assert qcqp.is_dual_feasible(lags)
+    v = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    kwargs = dict(get_grad=True, get_hess=True, penalty_vectors=[1e-3 * v])
+
+    dual_map, grad_map, hess_map, aux_map = qcqp.get_dual(lags, **kwargs)
+    assert qcqp._assembly_map is not None, "expected a fixed-pattern map here"
+
+    qcqp._assembly_map_max_bytes = 1  # force the elementwise sum
+    qcqp._invalidate_factor_cache()
+    dual_el, grad_el, hess_el, aux_el = qcqp.get_dual(lags, **kwargs)
+    assert qcqp._assembly_map is None
+
+    assert np.isclose(dual_map, dual_el, rtol=1e-11)
+    assert np.allclose(grad_map, grad_el, rtol=1e-9, atol=1e-11)
+    assert np.allclose(hess_map, hess_el, rtol=1e-9, atol=1e-11)
+    assert np.allclose(aux_map.grad_penalty, aux_el.grad_penalty, rtol=1e-9, atol=1e-11)
+    assert np.allclose(aux_map.hess_penalty, aux_el.hess_penalty, rtol=1e-9, atol=1e-11)
+
+
+def test_assembly_map_preserves_real_dtype():
+    """A real-valued problem must stay real: promoting A(lags) to complex would double
+    CHOLMOD's memory and factorization cost."""
+    qcqp = _real_sparse_qcqp_for_assembly()
+    lags = np.abs(qcqp.find_feasible_lags())
+    assert qcqp.A0.dtype == np.float64  # else the fixture is not exercising this
+    assert all(Ak.dtype == np.float64 for Ak in qcqp.precomputed_As)
+
+    got = qcqp._get_total_A(lags)
+    assert qcqp._assembly_map is not None, "expected a fixed-pattern map here"
+    want = _elementwise_total_A(qcqp, lags)
+    assert got.dtype == want.dtype == np.float64
+    _assert_total_A_matches_elementwise(qcqp, lags)
 
 
 def test_assembly_map_dropped_on_constraint_edits(sparse_qcqp_data):


### PR DESCRIPTION
The two most time consuming aspects of calculating the sparse dual bounds are the cholesky factorization (naturally) and the calculation of total_A, which is a sparse sum of a bunch of matrices (should not be the case). I've long suspected that the latter could be massively improved because the sparsity pattern is known ahead of time. Indeed, storing the sparsity pattern gives a 5-60x performance improvement for get_total_A, and about a 3x improvement end-to-end (2x for GCD). This improvement is larger when there are more constraints - the iterative splitting example is about 10x faster.

compute_precomputed_values is about 1.1-2x slower now because it needs to build this sparsity pattern, but it is more than made up by the gains, even in GCD which calls it multiple times. 