### PR TITLE
Add Pdiags="local" option

### DIFF
--- a/dolphindes/photonics/_base_photonics.py
+++ b/dolphindes/photonics/_base_photonics.py
@@ -244,6 +244,39 @@ class Photonics_FDFD(ABC):
         if c0 is not None:
             self.c0 = c0
 
+    def _build_projector_list(
+        self, n_des: int, Pdiags: str, phase: float | None = None
+    ) -> list[sp.csc_array]:
+        """Build the projector list for the requested shared-constraint basis."""
+        Id = sp.eye_array(n_des, dtype=complex, format="csc")
+
+        if Pdiags == "global":
+            return [Id, (-1j) * Id]
+
+        if Pdiags == "local":
+            # the last one-hot projector is dropped since it is the difference
+            # between the identity and the other one-hots
+            local_one_hot_projectors = [
+                sp.csc_array(
+                    ([1.0], ([idx], [idx])),
+                    shape=(n_des, n_des),
+                    dtype=complex,
+                )
+                for idx in range(n_des - 1)
+            ]
+            return (
+                [Id, (-1j) * Id]
+                + local_one_hot_projectors
+                + [(-1j) * projector for projector in local_one_hot_projectors]
+            )
+
+        if Pdiags == "phase":
+            if phase is None:
+                raise ValueError("phase argument must be specified for Pdiags='phase'")
+            return [np.exp(1j * phase) * Id]
+
+        raise ValueError("Not a valid Pdiags specification / needs implementation")
+
     def setup_QCQP(
         self, Pdiags: str = "global", verbose: float = 0, phase: float | None = None
     ) -> None:
@@ -253,8 +286,10 @@ class Photonics_FDFD(ABC):
         Parameters
         ----------
         Pdiags : str or ndarray, optional
-            Specification for projection matrix diagonals. If "global", creates
-            global projectors with ones and -1j entries. Default: "global"
+            Specification for projection matrix diagonals. "global" creates
+            [I, -1j I], "local" appends the one-hot projectors [E_i, -1j E_i]
+            (dropping the last pixel for linear independence), and "phase"
+            creates [exp(1j * phase) I]. Default: "global"
         verbose : float, optional
             Verbosity level for debugging output. Default: 0
 
@@ -288,16 +323,7 @@ class Photonics_FDFD(ABC):
 
         self.get_ei(self.ji, update=True)
 
-        if Pdiags == "global":
-            Id = sp.eye_array(self.Ndes, dtype=complex, format="csc")
-            self.Plist = [Id, (-1j) * Id]
-        elif Pdiags == "phase":
-            if phase is None:
-                raise ValueError("phase argument must be specified for Pdiags='phase'")
-            Id = sp.eye_array(self.Ndes, dtype=complex, format="csc")
-            self.Plist = [np.exp(1j * phase) * Id]
-        else:
-            raise ValueError("Not a valid Pdiags specification / needs implementation")
+        self.Plist = self._build_projector_list(self.Ndes, Pdiags, phase)
 
         assert self.chi is not None
         assert self.ei is not None

--- a/tests/test_polar_photonics.py
+++ b/tests/test_polar_photonics.py
@@ -131,6 +131,69 @@ class TestPhotonicsTMFDFDPolar:
         assert problem.QCQP is not None
         assert problem.Ndes == setup["Ndes"]
 
+    def test_setup_qcqp_local_dense(self):
+        """Test dense QCQP setup with local one-hot projectors."""
+        wavelength = 1.0
+        omega = 2 * np.pi / wavelength
+        chi = 3 + 1e-2j
+
+        dr = 0.25
+        Nr = 8
+        Nphi = 4
+        Npml = 1
+        n_sectors = 1
+
+        geometry = PolarFDFDGeometry(
+            Nphi=Nphi,
+            Nr=Nr,
+            Npml=Npml,
+            dr=dr,
+            n_sectors=n_sectors,
+            bloch_phase=0.0,
+        )
+
+        des_mask = np.zeros((Nr, Nphi), dtype=bool)
+        des_mask[2:4, :] = True
+        Ndes = int(np.sum(des_mask))
+
+        r_grid = (np.arange(Nr) + 0.5) * dr
+        area_r = r_grid * dr * (2 * np.pi / n_sectors / Nphi)
+        area_vec = np.kron(np.ones(Nphi), area_r)
+
+        ji = np.zeros(Nr * Nphi, dtype=complex)
+        ji[1] = 1.0 / area_vec[1]
+
+        problem = Photonics_TM_FDFD(
+            omega=omega,
+            geometry=geometry,
+            chi=chi,
+            des_mask=des_mask,
+            ji=ji,
+            sparseQCQP=False,
+        )
+        problem.get_ei(ji, update=True)
+        problem.set_objective(
+            A0=sp.csc_array((Ndes, Ndes), dtype=complex),
+            s0=np.zeros(Ndes, dtype=complex),
+            c0=0.0,
+            denseToSparse=False,
+        )
+        problem.setup_QCQP(Pdiags="local")
+
+        assert problem.QCQP is not None
+        assert problem.Plist is not None
+        assert problem.QCQP.n_proj_constr == 2 * Ndes
+        assert len(problem.Plist) == 2 * Ndes
+
+        # [I, -1j I] followed by the first Ndes - 1 one-hots and their -1j copies
+        Pdiags = problem.QCQP.Proj.Pdiags
+        assert Pdiags.shape == (Ndes, 2 * Ndes)
+        one_hots = np.eye(Ndes)[:, : Ndes - 1]
+        assert np.allclose(Pdiags[:, 0], np.ones(Ndes))
+        assert np.allclose(Pdiags[:, 1], -1j * np.ones(Ndes))
+        assert np.allclose(Pdiags[:, 2 : Ndes + 1], one_hots)
+        assert np.allclose(Pdiags[:, Ndes + 1 :], -1j * one_hots)
+
     def test_bound_qcqp(self, absorption_problem_setup):
         """Test that QCQP bound can be computed."""
         setup = absorption_problem_setup


### PR DESCRIPTION
Adds `Pdiags="local"` to `setup_QCQP`: the two global projectors `[I, -1j I]` plus the one-hot projectors `[E_i, -1j E_i]`, dropping the last pixel so the set stays linearly independent (2*Ndes constraints total). Projector construction is factored into `_build_projector_list`.

Checked on a planewave absorption problem (Ndes=100): the dual solves from a cold start and tightens the global bound from 0.02136 to 0.01099, sparse and dense agreeing. The 200 projector diagonals have full real rank.